### PR TITLE
Fixed propagation of return values for some verb calls

### DIFF
--- a/libdisni/src/verbs/com_ibm_disni_rdma_verbs_impl_NativeDispatcher.cpp
+++ b/libdisni/src/verbs/com_ibm_disni_rdma_verbs_impl_NativeDispatcher.cpp
@@ -487,14 +487,6 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1dis
 
 	if (cm_listen_id != NULL){
 		ret = rdma_disconnect(cm_listen_id);
-		if (ret == 0){
-			pthread_rwlock_wrlock(&mut_cm_id);
-			map_cm_id.erase(id);
-			pthread_rwlock_unlock(&mut_cm_id);
-			log("j2c::disconnect: ret %i\n", ret);
-		} else {
-			log("j2c::disconnect: rdma_disconnect failed\n");
-		}
 	} else {
 		log("j2c:disconnect: cm_listen_id null\n");
 	}
@@ -541,7 +533,6 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1des
 		pthread_rwlock_wrlock(&mut_cm_id);
 		map_cm_id.erase(id);
 		pthread_rwlock_unlock(&mut_cm_id);
-		ret = 0;
 	}
 
 	return ret;
@@ -561,11 +552,13 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1des
 	cm_listen_id = map_cm_id[id];
 	pthread_rwlock_unlock(&mut_cm_id);
 
-	if (cm_listen_id != NULL){
+	if (cm_listen_id != NULL && cm_listen_id->qp != NULL){
+		jlong obj_id = createObjectId(cm_listen_id->qp);
+		pthread_rwlock_wrlock(&mut_qp);
+		map_qp.erase(obj_id);
+		pthread_rwlock_unlock(&mut_qp);
+
 		rdma_destroy_qp(cm_listen_id);
-		pthread_rwlock_wrlock(&mut_cm_id);
-		map_cm_id.erase(id);
-		pthread_rwlock_unlock(&mut_cm_id);
 		ret = 0;
 	}
 
@@ -1078,7 +1071,6 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1des
 		pthread_rwlock_wrlock(&mut_comp_channel);
 		map_comp_channel.erase(channel);
 		pthread_rwlock_unlock(&mut_comp_channel);
-		ret = 0;
 	}
 
 	return ret;
@@ -1102,7 +1094,6 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1dea
 		pthread_rwlock_wrlock(&mut_pd);
 		map_pd.erase(pd);
 		pthread_rwlock_unlock(&mut_pd);
-		ret = 0;
 	}
 
 	return ret;
@@ -1126,7 +1117,6 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1des
 		pthread_rwlock_wrlock(&mut_cq);
 		map_cq.erase(cq);
 		pthread_rwlock_unlock(&mut_cq);
-		ret = 0;
 	}
 
 	return ret;

--- a/src/main/java/com/ibm/disni/rdma/verbs/RdmaCmId.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/RdmaCmId.java
@@ -145,16 +145,16 @@ public class RdmaCmId  {
 		return cm.accept(this, connParam);
 	}
 	
-	public void disconnect() throws IOException{
-		cm.disconnect(this);
+	public int disconnect() throws IOException{
+		return cm.disconnect(this);
 	}
 	
-	public void destroyId() throws IOException {
-		cm.destroyCmId(this);
+	public int destroyId() throws IOException {
+		return cm.destroyCmId(this);
 	}
 	
-	public void destroyQP() throws IOException {
-		cm.destroyQP(this);
+	public int destroyQP() throws IOException {
+		return cm.destroyQP(this);
 	}	
 	
 	public SocketAddress getSource() throws IOException {
@@ -165,7 +165,7 @@ public class RdmaCmId  {
 		return cm.getDstAddr(this);
 	}
 	
-	public void destroyEp() throws IOException {
-		cm.destroyEp(this);
+	public int destroyEp() throws IOException {
+		return cm.destroyEp(this);
 	}	
 }

--- a/src/main/java/com/ibm/disni/rdma/verbs/RdmaEventChannel.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/RdmaEventChannel.java
@@ -65,7 +65,7 @@ public class RdmaEventChannel {
 		return cm.getCmEvent(this, timeout);
 	}
 	
-	public void destroyEventChannel() throws IOException{
-		cm.destroyEventChannel(this);
+	public int destroyEventChannel() throws IOException{
+		return cm.destroyEventChannel(this);
 	}
 } 


### PR DESCRIPTION
Fixed some tear down handling of QPs, CM IDs, as well as other components which didn't have their return value propagated properly.

For QPs and CM IDs, the CM ID was improperly removed from the map in case of rdma_disconnect() and rdma_destroy_qp(). Instead, the code now removes the CM_ID only when it is destroyed, and removes the QP from the map upon rdma_destroy_qp().