### PR TITLE
Removed shared maps.

### DIFF
--- a/libdisni/src/verbs/com_ibm_disni_rdma_verbs_impl_NativeDispatcher.cpp
+++ b/libdisni/src/verbs/com_ibm_disni_rdma_verbs_impl_NativeDispatcher.cpp
@@ -28,7 +28,6 @@
 
 #include "com_ibm_disni_rdma_verbs_impl_NativeDispatcher.h"
 #include <rdma/rdma_cma.h>
-#include <map>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -44,8 +43,6 @@
 #include <inttypes.h>
 #include <stddef.h>
 
-using namespace std;
-
 //#define MAX_WR 200;
 #define MAX_SGE 4;
 //#define N_CQE 200
@@ -53,32 +50,8 @@ using namespace std;
 
 //global resource id counter
 static unsigned long long counter = 0;
-//event channel: system wide
-static map<unsigned long long, struct rdma_event_channel *> map_cm_channel;
-//cm id: device specific
-static map<unsigned long long, struct rdma_cm_id *> map_cm_id;
-//pd: device specific
-static map<unsigned long long, struct ibv_pd *> map_pd;
-//device: system wide
-static map<unsigned long long, struct ibv_context *> map_context;
-//comp_channel: system wide
-static map<unsigned long long, struct ibv_comp_channel *> map_comp_channel;
-//cq: device specific
-static map<unsigned long long, struct ibv_cq *> map_cq;
-//qp: device specific
-static map<unsigned long long, struct ibv_qp *> map_qp;
-//mr: device specific
-static map<unsigned long long, struct ibv_mr *> map_mr;
 
 static pthread_mutex_t mut_counter = PTHREAD_MUTEX_INITIALIZER;
-static pthread_rwlock_t mut_cm_channel = PTHREAD_RWLOCK_INITIALIZER;
-static pthread_rwlock_t mut_cm_id = PTHREAD_RWLOCK_INITIALIZER;
-static pthread_rwlock_t mut_pd = PTHREAD_RWLOCK_INITIALIZER;
-static pthread_rwlock_t mut_context = PTHREAD_RWLOCK_INITIALIZER;
-static pthread_rwlock_t mut_comp_channel = PTHREAD_RWLOCK_INITIALIZER;
-static pthread_rwlock_t mut_cq = PTHREAD_RWLOCK_INITIALIZER;
-static pthread_rwlock_t mut_qp = PTHREAD_RWLOCK_INITIALIZER;
-static pthread_rwlock_t mut_mr = PTHREAD_RWLOCK_INITIALIZER;
 
 #ifdef ENABLE_LOGGING
 #define log(...)\
@@ -121,9 +94,6 @@ JNIEXPORT jlong JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1cr
 		int flags = fcntl(cm_channel->fd, F_GETFL);
 		int rc = fcntl(cm_channel->fd, F_SETFL, flags | O_NONBLOCK);
 		obj_id = createObjectId(cm_channel);
-		pthread_rwlock_wrlock(&mut_cm_channel);
-		map_cm_channel[obj_id] = cm_channel;
-		pthread_rwlock_unlock(&mut_cm_channel);
 		log("j2c::createEventChannel: obj_id %llu\n", obj_id);
 	} else {
 		log("j2c::createEventChannel: rdma_create_event_channel failed\n");
@@ -143,17 +113,12 @@ JNIEXPORT jlong JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1cr
 	struct rdma_event_channel *cm_channel = NULL;
 	unsigned long long obj_id = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_channel);
-	cm_channel = map_cm_channel[channel];
-	pthread_rwlock_unlock(&mut_cm_channel);
+	cm_channel = (struct rdma_event_channel *)channel;
 	if (cm_channel != NULL){
 		int ret = rdma_create_id(cm_channel, &cm_listen_id, NULL, RDMA_PS_TCP);
 		if (ret == 0){
 			obj_id = createObjectId(cm_listen_id);
 			//obj_id = (unsigned long long) cm_listen_id;
-			pthread_rwlock_wrlock(&mut_cm_id);
-			map_cm_id[obj_id] = cm_listen_id;
-			pthread_rwlock_unlock(&mut_cm_id);
 			log("j2c::createId: ret %i, obj_id %p\n", ret, (void *)cm_listen_id);
 		} else {
 			log("j2c::createId: rdma_create_id failed\n");
@@ -182,18 +147,10 @@ JNIEXPORT jlong JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1cr
 	int _maxrecvwr = maxrecvwr;
 	enum ibv_qp_type _qptype = (enum ibv_qp_type) qptype;
 
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
-	pthread_rwlock_rdlock(&mut_pd);
-	protection = map_pd[pd];
-	pthread_rwlock_unlock(&mut_pd);
-	pthread_rwlock_rdlock(&mut_cq);
-	send_cq = map_cq[sendcq];
-	pthread_rwlock_unlock(&mut_cq);
-	pthread_rwlock_rdlock(&mut_cq);
-	recv_cq = map_cq[recvcq];
-	pthread_rwlock_unlock(&mut_cq);
+	cm_listen_id = (struct rdma_cm_id *)id;
+	protection = (struct ibv_pd *)pd;
+	send_cq = (struct ibv_cq *)sendcq;
+	recv_cq = (struct ibv_cq *)recvcq;
 
 	if (cm_listen_id != NULL && protection != NULL && send_cq != NULL && recv_cq != NULL){
 		memset(&qp_init_attr, 0, sizeof qp_init_attr);
@@ -211,9 +168,6 @@ JNIEXPORT jlong JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1cr
 		if (ret == 0){
 			struct ibv_qp *qp = cm_listen_id->qp;
 			obj_id = createObjectId(qp);
-			pthread_rwlock_wrlock(&mut_qp);
-			map_qp[obj_id] = qp;
-			pthread_rwlock_unlock(&mut_qp);
 			log("j2c::createQP: obj_id %llu, qpnum %u, send_wr %u, recv_wr %u \n", obj_id, cm_listen_id->qp->qp_num, qp_init_attr.cap.max_send_wr, qp_init_attr.cap.max_recv_wr);
 
 			struct ibv_qp_attr tmp_attr;
@@ -240,9 +194,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1bin
 	struct sockaddr_in *s_addr = (struct sockaddr_in *) address;	
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
+	cm_listen_id = (struct rdma_cm_id *)id;
 
 	if (cm_listen_id != NULL){
 		ret = rdma_bind_addr(cm_listen_id, (struct sockaddr*) s_addr);
@@ -268,9 +220,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1lis
 	struct rdma_cm_id *cm_listen_id = NULL;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
+	cm_listen_id = (struct rdma_cm_id *)id;
 	if (cm_listen_id != NULL){
 		ret = rdma_listen(cm_listen_id, backlog);
 		if (ret == 0){
@@ -296,9 +246,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1res
 	struct sockaddr_in *d_addr = (struct sockaddr_in *) dst;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
+	cm_listen_id = (struct rdma_cm_id *)id;
 	if (cm_listen_id != NULL){
 		ret = rdma_resolve_addr(cm_listen_id, NULL, (struct sockaddr*) d_addr, 2000);
 		if (ret == 0){
@@ -323,9 +271,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1res
 	struct rdma_cm_id *cm_listen_id = NULL;
 	jint ret = -1;
 	
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
+	cm_listen_id = (struct rdma_cm_id *)id;
 	if (cm_listen_id != NULL){
 		ret = rdma_resolve_route(cm_listen_id, 2000);
 		if (ret == 0){
@@ -352,9 +298,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1get
 	int _timeout = (int) timeout;
 	jint event = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_channel);
-	cm_channel = map_cm_channel[channel];
-	pthread_rwlock_unlock(&mut_cm_channel);
+	cm_channel = (struct rdma_event_channel *)channel;
 	if (cm_channel != NULL){
 		struct pollfd pollfdcm;
 		pollfdcm.fd = cm_channel->fd;
@@ -376,12 +320,6 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1get
 				unsigned long long *_client_id = (unsigned long long *) client_id;
 				if (cm_event->id != NULL){
 					*_client_id = (unsigned long long) cm_event->id;
-					if (cm_event->event == RDMA_CM_EVENT_CONNECT_REQUEST){
-						unsigned long long obj_id = (unsigned long long) cm_event->id;
-						pthread_rwlock_wrlock(&mut_cm_id);
-						map_cm_id[obj_id] = cm_event->id;
-						pthread_rwlock_unlock(&mut_cm_id);
-					}
 				} else {
 					*_client_id = -1;
 				}
@@ -404,9 +342,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1con
 	struct rdma_conn_param conn_param;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
+	cm_listen_id = (struct rdma_cm_id *)id;
 	struct ibv_device_attr dev_attr;
 	ibv_query_device(cm_listen_id->verbs, &dev_attr);
 
@@ -440,9 +376,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1acc
 	struct rdma_conn_param conn_param;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
+	cm_listen_id = (struct rdma_cm_id *)id;
         struct ibv_device_attr dev_attr;
         ibv_query_device(cm_listen_id->verbs, &dev_attr);
 
@@ -485,9 +419,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1dis
 	struct rdma_cm_id *cm_listen_id = NULL;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
+	cm_listen_id = (struct rdma_cm_id *)id;
 
 	if (cm_listen_id != NULL){
 		ret = rdma_disconnect(cm_listen_id);
@@ -503,15 +435,10 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1des
 	struct rdma_event_channel *cm_channel = NULL;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_channel);
-	cm_channel = map_cm_channel[channel];
-	pthread_rwlock_unlock(&mut_cm_channel);
+	cm_channel = (struct rdma_event_channel *)channel;
 
 	if (cm_channel != NULL){
 		rdma_destroy_event_channel(cm_channel);
-		pthread_rwlock_wrlock(&mut_cm_channel);
-		map_cm_channel.erase(channel);
-		pthread_rwlock_unlock(&mut_cm_channel);
 		ret = 0;
 	}
 
@@ -528,15 +455,10 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1des
 	struct rdma_cm_id *cm_listen_id = NULL;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
+	cm_listen_id = (struct rdma_cm_id *)id;
 
 	if (cm_listen_id != NULL){
 		ret = rdma_destroy_id(cm_listen_id);
-		pthread_rwlock_wrlock(&mut_cm_id);
-		map_cm_id.erase(id);
-		pthread_rwlock_unlock(&mut_cm_id);
 	}
 
 	return ret;
@@ -552,15 +474,10 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1des
 	struct rdma_cm_id *cm_listen_id = NULL;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
+	cm_listen_id = (struct rdma_cm_id *)id;
 
 	if (cm_listen_id != NULL && cm_listen_id->qp != NULL){
 		jlong obj_id = createObjectId(cm_listen_id->qp);
-		pthread_rwlock_wrlock(&mut_qp);
-		map_qp.erase(obj_id);
-		pthread_rwlock_unlock(&mut_qp);
 
 		rdma_destroy_qp(cm_listen_id);
 		ret = 0;
@@ -581,16 +498,11 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1des
 	struct rdma_cm_id *cm_listen_id = NULL;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
+	cm_listen_id = (struct rdma_cm_id *)id;
 
 	if (cm_listen_id != NULL){
 		log("j2c::destroyEp: id %p\n", (void *)id);
 		rdma_destroy_ep(cm_listen_id);
-		pthread_rwlock_wrlock(&mut_cm_id);
-		map_cm_id.erase(id);
-		pthread_rwlock_unlock(&mut_cm_id);
 		ret = 0;
 	}
 
@@ -607,9 +519,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1get
         struct rdma_cm_id *cm_listen_id = NULL;
         jint ret = -1;
 
-        pthread_rwlock_rdlock(&mut_cm_id);
-        cm_listen_id = map_cm_id[id];
-        pthread_rwlock_unlock(&mut_cm_id);
+        cm_listen_id = (struct rdma_cm_id *)id;
 
         if (cm_listen_id != NULL){
         	struct sockaddr *sock = rdma_get_local_addr(cm_listen_id);
@@ -633,9 +543,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1get
         struct rdma_cm_id *cm_listen_id = NULL;
         jint ret = -1;
 
-        pthread_rwlock_rdlock(&mut_cm_id);
-        cm_listen_id = map_cm_id[id];
-        pthread_rwlock_unlock(&mut_cm_id);
+        cm_listen_id = (struct rdma_cm_id *)id;
 
         if (cm_listen_id != NULL){
                 struct sockaddr *sock = rdma_get_peer_addr(cm_listen_id);
@@ -662,17 +570,12 @@ JNIEXPORT jlong JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1ge
 	//jint cmd_fd = -1;
 	unsigned long long obj_id = -1;
 
-	pthread_rwlock_rdlock(&mut_cm_id);
-	cm_listen_id = map_cm_id[id];
-	pthread_rwlock_unlock(&mut_cm_id);
+	cm_listen_id = (struct rdma_cm_id *)id;
 
 	if (cm_listen_id != NULL){
 		struct ibv_context *context = cm_listen_id->verbs;
                 if (context != NULL){
 			obj_id = createObjectId(context);
-                        pthread_rwlock_wrlock(&mut_context);
-                        map_context[obj_id] = context;
-                        pthread_rwlock_unlock(&mut_context);
                         log("j2c::getContext: obj_id %llu\n", obj_id);
                 } else {
                         log("j2c::getContext: context_list empty %p\n", (void *)cm_listen_id);
@@ -694,17 +597,12 @@ JNIEXPORT jlong JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1al
 	struct ibv_context *context = NULL;
 	unsigned long long obj_id = -1;
 
-	pthread_rwlock_rdlock(&mut_context);
-	context = map_context[ctx];
-	pthread_rwlock_unlock(&mut_context);
+	context = (struct ibv_context *)ctx;
 
 	if (context != NULL){
 		struct ibv_pd *pd = ibv_alloc_pd(context);
 		if (pd != NULL){
 			obj_id = createObjectId(pd);
-			pthread_rwlock_wrlock(&mut_pd);
-			map_pd[obj_id] = pd;
-			pthread_rwlock_unlock(&mut_pd);
 			log("j2c::allocPd: obj_id %llu\n", obj_id);
 		} else {
 			log("j2c::allocPd: ibv_alloc_pd failed\n");
@@ -726,18 +624,13 @@ JNIEXPORT jlong JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1cr
 	struct ibv_context *context = NULL;
 	unsigned long long obj_id = -1;
 
-	pthread_rwlock_rdlock(&mut_context);
-	context = map_context[ctx];
-	pthread_rwlock_unlock(&mut_context);
+	context = (struct ibv_context *)ctx;
 	if (context != NULL){
 		struct ibv_comp_channel *comp_channel = ibv_create_comp_channel(context);
 		if (comp_channel != NULL){
 			int flags = fcntl(comp_channel->fd, F_GETFL);
 			int rc = fcntl(comp_channel->fd, F_SETFL, flags | O_NONBLOCK);
 			obj_id = createObjectId(comp_channel);
-			pthread_rwlock_wrlock(&mut_comp_channel);
-			map_comp_channel[obj_id] = comp_channel;
-			pthread_rwlock_unlock(&mut_comp_channel);
 			log("j2c::createCompChannel: obj_id %llu\n", obj_id);
 		} else {
 			log("j2c::createCompChannel: ibv_create_comp_channel failed\n");
@@ -762,20 +655,13 @@ JNIEXPORT jlong JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1cr
 	int _ncqe = ncqe;
 	int _comp_vector = comp_vector;
 	
-	pthread_rwlock_rdlock(&mut_context);
-	context = map_context[ctx];
-	pthread_rwlock_unlock(&mut_context);
-	pthread_rwlock_rdlock(&mut_comp_channel);
-	comp_channel = map_comp_channel[channel];
-	pthread_rwlock_unlock(&mut_comp_channel);
+	context = (struct ibv_context *)ctx;
+	comp_channel = (struct ibv_comp_channel *)channel;
 
 	if (context != NULL && comp_channel != NULL){
 		struct ibv_cq *cq = ibv_create_cq(context, _ncqe, NULL, comp_channel, _comp_vector);
 		if (cq != NULL){
 			obj_id = createObjectId(cq);
-			pthread_rwlock_wrlock(&mut_cq);
-			map_cq[obj_id] = cq;
-			pthread_rwlock_unlock(&mut_cq);
 			log("j2c::createCQ: obj_id %p, cq %p, cqnum %u, size %u\n", (void *)obj_id, (void *)cq, cq->handle, _ncqe);
 		} else {
 			log("j2c::createCQ: ibv_create_cq failed\n");
@@ -800,9 +686,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1mod
 	int attr_mask;	
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_qp);
-	queuepair = map_qp[qp];
-	pthread_rwlock_unlock(&mut_qp);
+	queuepair = (struct ibv_qp *)qp;
 	if (queuepair != NULL){
 		ret = ibv_modify_qp(queuepair, &attr, attr_mask);
 		if (ret == 0){
@@ -829,16 +713,11 @@ JNIEXPORT jlong JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1re
 	//jint ret = -1;
 	unsigned long long obj_id = -1;
 	
-	pthread_rwlock_rdlock(&mut_pd);
-	protection = map_pd[pd];
-	pthread_rwlock_unlock(&mut_pd);
+	protection = (struct ibv_pd *)pd;
 	if (protection != NULL){
 		struct ibv_mr *mr = ibv_reg_mr(protection, addr, len, access);
 		if (mr != NULL){
 			obj_id = createObjectId(mr);
-			pthread_rwlock_wrlock(&mut_mr);
-			map_mr[obj_id] = mr;
-			pthread_rwlock_unlock(&mut_mr);
 
 			int *_lkey = (int *) lkey;
 			int *_rkey = (int *) rkey;
@@ -870,14 +749,9 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1der
 	struct ibv_mr *mr = NULL;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_mr);
-	mr = map_mr[handle];
-	pthread_rwlock_unlock(&mut_mr);
+	mr = (struct ibv_mr *)handle;
 
 	if (mr != NULL){
-		pthread_rwlock_wrlock(&mut_mr);
-		map_mr.erase(handle);
-		pthread_rwlock_unlock(&mut_mr);
 		ret = ibv_dereg_mr(mr);
 		if (ret == 0){
 			log("j2c::deregMr: ret %i\n", ret);
@@ -903,9 +777,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1pos
 	struct ibv_send_wr *bad_wr;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_qp);
-	queuepair = map_qp[qp];
-	pthread_rwlock_unlock(&mut_qp);
+	queuepair = (struct ibv_qp *)qp;
 	if (queuepair != NULL){
 		ret = ibv_post_send(queuepair, wr, &bad_wr);
 		if (ret == 0){
@@ -933,9 +805,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1pos
 	struct ibv_recv_wr *bad_wr;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_qp);
-	queuepair = map_qp[qp];
-	pthread_rwlock_unlock(&mut_qp);
+	queuepair = (struct ibv_qp *)qp;
 	if (queuepair != NULL){
 		//log("j2c::post_recv: sizeof wr %zu, wrid %llu\n", sizeof *wr, wr->wr_id);
 		ret = ibv_post_recv(queuepair, wr, &bad_wr);
@@ -963,9 +833,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1get
 	void *dst_cq_ctx;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_comp_channel);
-	comp_channel = map_comp_channel[channel];
-	pthread_rwlock_unlock(&mut_comp_channel);
+	comp_channel = (struct ibv_comp_channel *)channel;
 
 	if (comp_channel != NULL){
 		struct pollfd pollfdcomp;
@@ -997,9 +865,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1pol
 	int num_entries = (int) ne;	
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cq);
-	completionqueue = map_cq[cq];
-	pthread_rwlock_unlock(&mut_cq);
+	completionqueue = (struct ibv_cq*)cq;
 	if (completionqueue != NULL){
 		ret = ibv_poll_cq(completionqueue, num_entries, wc);
 		//log("j2c::pollCQ: ret %i\n", ret);
@@ -1021,9 +887,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1req
 	int solicited_only = (int) solicited;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cq);
-	completionqueue = map_cq[cq];
-	pthread_rwlock_unlock(&mut_cq);
+	completionqueue = (struct ibv_cq*)cq;
 
 	if (completionqueue != NULL){
 		ret = ibv_req_notify_cq(completionqueue, solicited_only);
@@ -1046,9 +910,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1ack
 	unsigned int num_events = (unsigned int) nevents;
 	jint ret = -1;
 	
-	pthread_rwlock_rdlock(&mut_cq);
-	completionqueue = map_cq[cq];
-	pthread_rwlock_unlock(&mut_cq);
+	completionqueue = (struct ibv_cq*)cq;
 
 	if (completionqueue != NULL){
 		ibv_ack_cq_events(completionqueue, num_events);
@@ -1068,14 +930,9 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1des
 	struct ibv_comp_channel *comp_channel = NULL;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_comp_channel);
-	comp_channel = map_comp_channel[channel];
-	pthread_rwlock_unlock(&mut_comp_channel);
+	comp_channel = (struct ibv_comp_channel *)channel;
 	if (comp_channel != NULL){
 		ret = ibv_destroy_comp_channel(comp_channel);
-		pthread_rwlock_wrlock(&mut_comp_channel);
-		map_comp_channel.erase(channel);
-		pthread_rwlock_unlock(&mut_comp_channel);
 	}
 
 	return ret;
@@ -1091,14 +948,9 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1dea
 	struct ibv_pd *protection = NULL;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_pd);
-	protection = map_pd[pd];
-	pthread_rwlock_unlock(&mut_pd);
+	protection = (struct ibv_pd *)pd;
 	if (protection != NULL){
 		ret = ibv_dealloc_pd(protection);
-		pthread_rwlock_wrlock(&mut_pd);
-		map_pd.erase(pd);
-		pthread_rwlock_unlock(&mut_pd);
 	}
 
 	return ret;
@@ -1114,14 +966,9 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1des
 	struct ibv_cq *completionqueue = NULL;
 	jint ret = -1;
 
-	pthread_rwlock_rdlock(&mut_cq);
-	completionqueue = map_cq[cq];
-	pthread_rwlock_unlock(&mut_cq);
+	completionqueue = (struct ibv_cq*)cq;
 	if (completionqueue != NULL){
 		ret = ibv_destroy_cq(completionqueue);
-		pthread_rwlock_wrlock(&mut_cq);
-		map_cq.erase(cq);
-		pthread_rwlock_unlock(&mut_cq);
 	}
 
 	return ret;
@@ -1136,9 +983,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1get
   (JNIEnv *env, jobject obj, jlong obj_id){
 	jint qpnum = -1;
 
-	pthread_rwlock_rdlock(&mut_qp);
-	struct ibv_qp *qp = map_qp[obj_id];
-	pthread_rwlock_unlock(&mut_qp);
+	struct ibv_qp * qp = (struct ibv_qp *)obj_id;
 	if (qp != NULL){
 		qpnum = qp->qp_num;
 		log("j2c::getQpNum: obj_id %p, qpnum %i\n", (void *)obj_id, qpnum);
@@ -1158,9 +1003,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1get
   (JNIEnv *env, jobject obj, jlong obj_id){
         jint cmd_fd = -1;
 
-        pthread_rwlock_rdlock(&mut_context);
-        struct ibv_context *context = map_context[obj_id];
-        pthread_rwlock_unlock(&mut_context);
+        struct ibv_context *context = (struct ibv_context *)obj_id;
         if (context != NULL){
                 cmd_fd = context->cmd_fd;
                 log("j2c::getContextFd: obj_id %p, fd %i\n", (void *)obj_id, cmd_fd);
@@ -1180,9 +1023,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1get
   (JNIEnv *env, jobject obj, jlong pd){
 	jint handle = -1;
 
-	pthread_rwlock_rdlock(&mut_pd);
-	struct ibv_pd *protection = map_pd[pd];
-	pthread_rwlock_unlock(&mut_pd);
+	struct ibv_pd *protection = (struct ibv_pd *)pd;
 	if (protection != NULL){
 		handle = protection->handle;
 		log("j2c::getPdHandle: obj_id %p, handle %i\n", (void *)pd, handle);

--- a/src/main/java/com/ibm/disni/rdma/verbs/IbvCQ.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/IbvCQ.java
@@ -51,12 +51,14 @@ public class IbvCQ {
 	protected IbvCompChannel channel;
 	protected int cqe;
 	protected int handle;
+	protected volatile boolean isOpen;
 
 	public IbvCQ(IbvContext context, IbvCompChannel compChannel, int handle) throws IOException  {
 		this.verbs = RdmaVerbs.open();
 		this.context = context;
 		this.channel = compChannel;
 		this.handle = handle;
+		this.isOpen = true;
 	}
 
 	/**
@@ -95,6 +97,14 @@ public class IbvCQ {
 		return cqe;
 	}
 	
+	public boolean isOpen() {
+		return isOpen;
+	}
+
+	public void close() {
+		isOpen = false;
+	}
+
 	//---------- oo-verbs
 	
 	public SVCPollCq poll(IbvWC[] wcList, int ne) throws IOException {

--- a/src/main/java/com/ibm/disni/rdma/verbs/IbvCompChannel.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/IbvCompChannel.java
@@ -36,11 +36,13 @@ public class IbvCompChannel {
 	private RdmaVerbs verbs;
 	private int fd;
 	protected IbvContext context;
+	protected volatile boolean isOpen;
 
 	protected IbvCompChannel(int fd, IbvContext context) throws IOException {
 		this.verbs = RdmaVerbs.open();
 		this.fd = fd;
 		this.context = context;
+		this.isOpen = true;
 	}
 
 	/**
@@ -61,6 +63,14 @@ public class IbvCompChannel {
 		return this.context;
 	}
 	
+	public boolean isOpen() {
+		return isOpen;
+	}
+
+	public void close() {
+		isOpen = false;
+	}
+
 	//---------- oo-verbs
 	
 	public boolean getCqEvent(IbvCQ cq, int timeout) throws IOException {

--- a/src/main/java/com/ibm/disni/rdma/verbs/IbvContext.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/IbvContext.java
@@ -40,21 +40,31 @@ import java.io.IOException;
 public class IbvContext  {
 	private RdmaVerbs verbs;
 	protected int cmd_fd;
+	protected boolean isOpen;
 	
 	protected IbvContext(int cmd_fd) throws IOException{
 		this.verbs = RdmaVerbs.open();
 		this.cmd_fd = cmd_fd;
+		this.isOpen = true;
 	}
 
 	/**
 	 * Retrieves the file descriptor used to implement this device context.
 	 *
 	 * @return the cmd_fd
+	 * @throws IOException
 	 */
-	public int getCmd_fd() {
+	public int getCmd_fd() throws IOException {
 		return cmd_fd;
 	}
 	
+	public boolean isOpen() {
+		return isOpen;
+	}
+
+	public void close() {
+		isOpen = false;
+	}
 	//---------- oo-verbs
 	
 	public IbvPd allocPd() throws IOException{

--- a/src/main/java/com/ibm/disni/rdma/verbs/IbvMr.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/IbvMr.java
@@ -55,6 +55,7 @@ public class IbvMr {
 	protected int lkey;
 	protected int rkey;
 	protected int handle;
+	protected volatile boolean isOpen;
 
 //	public IbvMr() throws IOException {
 //		this.context = null;
@@ -69,6 +70,7 @@ public class IbvMr {
 		this.lkey = lkey;
 		this.rkey = rkey;
 		this.handle = handle;
+		this.isOpen = true;
 	}
 
 	/**
@@ -167,6 +169,14 @@ public class IbvMr {
 		return this.context;
 	}
 	
+	public boolean isOpen() {
+		return isOpen;
+	}
+
+	public void close() {
+		isOpen = false;
+	}
+
 	//---------- oo-verbs
 	
 	public SVCDeregMr deregMr() throws IOException {

--- a/src/main/java/com/ibm/disni/rdma/verbs/IbvPd.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/IbvPd.java
@@ -38,6 +38,7 @@ public class IbvPd  {
 	
 	protected int handle;
 	protected IbvContext context;
+	protected volatile boolean isOpen;
 
 //	protected IbvPd() throws IOException{
 //		this.verbs = RdmaVerbs.open();
@@ -46,14 +47,16 @@ public class IbvPd  {
 	public IbvPd(IbvContext context) throws IOException {
 		this.verbs = RdmaVerbs.open();
 		this.context = context;
+		this.isOpen = true;
 	}
 
 	/**
 	 * A unique handle identifying this protection domain.
 	 *
 	 * @return the handle
+	 * @throws IOException
 	 */
-	public int getHandle() {
+	public int getHandle() throws IOException {
 		return handle;
 	}
 	
@@ -66,6 +69,14 @@ public class IbvPd  {
 		return context;
 	}
 	
+	public boolean isOpen() {
+		return isOpen;
+	}
+
+	public void close() {
+		isOpen = false;
+	}
+
 	//---------- oo-verbs
 	
 	public SVCRegMr regMr(ByteBuffer buffer, int access) throws IOException {

--- a/src/main/java/com/ibm/disni/rdma/verbs/IbvQP.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/IbvQP.java
@@ -74,10 +74,12 @@ public class IbvQP {
 	protected int qp_num;
 	protected int state;
 	protected int qp_type;
+	protected volatile boolean isOpen;
 
 	public IbvQP(int qpnum) throws IOException {
 		this.verbs = RdmaVerbs.open();
 		this.qp_num = qpnum;
+		this.isOpen = true;
 	}
 
 	/**
@@ -130,7 +132,7 @@ public class IbvQP {
 	 *
 	 * @return the qp_num
 	 */
-	public int getQp_num() {
+	public int getQp_num() throws IOException {
 		return qp_num;
 	}
 
@@ -156,6 +158,14 @@ public class IbvQP {
 		return "handle=" + handle + ",qp_num=" + qp_num + ",state=" + state;
 	}	
 	
+	public boolean isOpen() {
+		return isOpen;
+	}
+
+	public void close() {
+		isOpen = false;
+	}
+
 	//---------- oo-verbs
 	
 	public SVCPostSend postSend(List<IbvSendWR> wrList, List<IbvSendWR> badwrList) throws IOException {

--- a/src/main/java/com/ibm/disni/rdma/verbs/RdmaCmId.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/RdmaCmId.java
@@ -47,12 +47,14 @@ public class RdmaCmId  {
 	protected RdmaEventChannel cmChannel;
 	protected IbvContext verbs;
 	protected IbvQP qpObj;
+	protected volatile boolean isOpen;
 
 	protected RdmaCmId(RdmaEventChannel cmChannel, IbvContext verbs) throws IOException {
 		this.cm = RdmaCm.open();
 		this.cmChannel = cmChannel;
 		this.verbs = verbs;
-		this.qpObj = null; 
+		this.qpObj = null;
+		this.isOpen = true;
 	}
 
 	/**
@@ -115,6 +117,14 @@ public class RdmaCmId  {
 		this.verbs = verbs;
 	}
 	
+	public boolean isOpen() {
+		return isOpen;
+	}
+
+	public void close() {
+		isOpen = false;
+	}
+
 	//---------- oo-verbs
 	
 	public IbvQP createQP(IbvPd pd, IbvQPInitAttr attr) throws IOException{

--- a/src/main/java/com/ibm/disni/rdma/verbs/RdmaEventChannel.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/RdmaEventChannel.java
@@ -35,10 +35,12 @@ import java.io.IOException;
 public class RdmaEventChannel {
 	private RdmaCm cm;
 	private int fd;
+	protected volatile boolean isOpen;
 	
 	protected RdmaEventChannel(int fd) throws IOException{
 		this.cm = RdmaCm.open();
 		this.fd = fd;
+		this.isOpen = true;
 	}
 
 	/**
@@ -50,6 +52,14 @@ public class RdmaEventChannel {
 		return fd;
 	}
 	
+	public boolean isOpen() {
+		return isOpen;
+	}
+
+	public void close() {
+		isOpen = false;
+	}
+
 	//---------- oo-verbs
 	
 	public static RdmaEventChannel createEventChannel() throws IOException{

--- a/src/main/java/com/ibm/disni/rdma/verbs/RdmaVerbs.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/RdmaVerbs.java
@@ -175,8 +175,9 @@ public abstract class RdmaVerbs {
 	 * @param cq the completion queue that generated the events in the first place.
 	 * @param nevents the number of events to be acknowledged.
 	 * @return returns 0 on success.
+	 * @throws IOException
 	 */
-	public abstract int ackCqEvents(IbvCQ cq, int nevents);
+	public abstract int ackCqEvents(IbvCQ cq, int nevents) throws IOException;
 	
 	/**
 	 * Destroys the completion event channel

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatCmaIdPrivate.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatCmaIdPrivate.java
@@ -24,6 +24,7 @@ package com.ibm.disni.rdma.verbs.impl;
 import java.io.IOException;
 
 import com.ibm.disni.rdma.verbs.IbvContext;
+import com.ibm.disni.rdma.verbs.IbvQP;
 import com.ibm.disni.rdma.verbs.RdmaCmId;
 import com.ibm.disni.rdma.verbs.RdmaEventChannel;
 
@@ -50,6 +51,9 @@ public class NatCmaIdPrivate extends RdmaCmId implements NatObject {
 	@Override
 	public IbvContext getVerbs() throws IOException {
 		if (verbs == null){
+			if (!isOpen()) {
+				throw new IOException("Trying to get context on closed ID");
+			}
 			long _obj_id = nativeDispatcher._getContext(objId);
 			if (_obj_id >= 0){
 				NatIbvContext context = new NatIbvContext(_obj_id, nativeDispatcher);
@@ -61,6 +65,10 @@ public class NatCmaIdPrivate extends RdmaCmId implements NatObject {
 	
 	public void setVerbs(IbvContext verbs){
 		super.setVerbs(verbs);
-	}	
+	}
+
+	protected void setQp(IbvQP qpObj) {
+		super.setQp(qpObj);
+	}
 
 }

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatDeregMrCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatDeregMrCall.java
@@ -46,6 +46,10 @@ public class NatDeregMrCall extends SVCDeregMr {
 	}
 
 	public SVCDeregMr execute() throws IOException {
+		if (!mr.isOpen()) {
+			throw new IOException("Trying to deregister closed memory region.");
+		}
+		mr.close();
 		int ret = nativeDispatcher._deregMr(mr.getObjId());
 		if (ret != 0){
 			throw new IOException("Memory de-registration failed, ret " + ret);

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatGetCqCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatGetCqCall.java
@@ -50,6 +50,9 @@ public class NatGetCqCall extends SVCGetCqEvent {
 
 	@Override
 	public SVCGetCqEvent execute() throws IOException {
+		if (!compChannel.isOpen()) {
+			throw new IOException("Trying to get CQ event on closed completion channel.");
+		}
 		int ret = nativeDispatcher._getCqEvent(compChannel.getObjId(), timeout);
 		if (ret != 0){
 			throw new IOException("GetCQEvent failed");

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatIbvContext.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatIbvContext.java
@@ -40,8 +40,11 @@ public class NatIbvContext extends IbvContext implements NatObject {
 	}
 
 	@Override
-	public int getCmd_fd() {
+	public int getCmd_fd() throws IOException {
 		if (this.cmd_fd < 0){
+			if (!isOpen()) {
+				throw new IOException("Trying to get context FD while context is already closed.");
+			}
 			this.cmd_fd = nativeDispatcher._getContextFd(objId);
 		}		
 		return super.getCmd_fd();

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatIbvPd.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatIbvPd.java
@@ -42,7 +42,10 @@ public class NatIbvPd extends IbvPd implements NatObject{
 	}
 
 	@Override
-	public int getHandle() {
+	public int getHandle() throws IOException {
+		if (!isOpen()) {
+			throw new IOException("Trying to get PD handle of closed PD.");
+		}
 		return nativeDispatcher._getPdHandle(objId);
 	}
 }

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatIbvQP.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatIbvQP.java
@@ -36,8 +36,11 @@ public class NatIbvQP extends IbvQP implements NatObject {
 	}
 	
 	@Override
-	public int getQp_num() {
+	public int getQp_num() throws IOException {
 		if (this.qp_num < 0){
+			if (!isOpen()) {
+				throw new IOException("Trying to get QP num of closed QP.");
+			}
 			this.qp_num = this.nativeDispatcher._getQpNum(objId);
 		}
 		return qp_num;

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPollCqCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPollCqCall.java
@@ -106,6 +106,9 @@ public class NatPollCqCall extends SVCPollCq {
 	@Override
 	public SVCPollCq execute() throws IOException {
 		this.result = 0;
+		if (!cq.isOpen()) {
+			throw new IOException("Trying to poll closed CQ.");
+		}
 		this.result = nativeDispatcher._pollCQ(cq.getObjId(),  ne, cmd.address());
 		if (result < 0){
 			throw new IOException("Polling CQ failed");

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostRecvCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostRecvCall.java
@@ -103,6 +103,9 @@ public class NatPostRecvCall extends SVCPostRecv {
 
 	@Override
 	public SVCPostRecv execute() throws IOException {
+		if (!qp.isOpen()) {
+			throw new IOException("Trying to post receive on closed QP");
+		}
 		int ret = nativeDispatcher._postRecv(qp.getObjId(), cmd.address());
 		if (ret != 0){
 			throw new IOException("Post recv failed");

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostSendCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostSendCall.java
@@ -108,6 +108,9 @@ public class NatPostSendCall extends SVCPostSend {
 
 	@Override
 	public SVCPostSend execute() throws IOException {
+		if (!qp.isOpen()) {
+			throw new IOException("Trying to post send on closed QP");
+		}
 		int ret = nativeDispatcher._postSend(qp.getObjId(), cmd.address());
 		if (ret != 0){
 			throw new IOException("Post send failed");

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatRegMrCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatRegMrCall.java
@@ -72,6 +72,9 @@ public class NatRegMrCall extends SVCRegMr {
 
 	public SVCRegMr execute() throws IOException {
 		cmd.getBuffer().clear();
+		if (!pd.isOpen()) {
+			throw new IOException("Trying to register memory with closed PD.");
+		}
 		long objId = nativeDispatcher._regMr(pd.getObjId(), userAddress, bufferCapacity, access, cmd.address(), cmd.address() + 4, cmd.address() + 8);
 		if (objId <= 0){
 			throw new IOException("Memory registration failed with " + objId);

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatReqNotifyCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatReqNotifyCall.java
@@ -49,6 +49,9 @@ public class NatReqNotifyCall extends SVCReqNotify {
 	}
 
 	public SVCReqNotify execute() throws IOException {
+		if (!cq.isOpen()) {
+			throw new IOException("Trying to execute reqNotifyCQ() on closed CQ.");
+		}
 		int ret = nativeDispatcher._reqNotifyCQ(cq.getObjId(), solicited);
 		if (ret != 0){
 			throw new IOException("Request for Notification failed");


### PR DESCRIPTION
Removing the maps, which are shared by all processing cores in the fast path, increases multicore performance significantly.

Please have a look at the proposed change.

A simple test with 8 processing server cores in the DaRPC benchmark show this improvement:

Original (8 server cores)
Statistics: 1149839.26 IOPS, diff: 5751496, time diff(ms): 5002
Statistics: 1148448.51 IOPS, diff: 5743391, time diff(ms): 5001
Statistics: 1151963.01 IOPS, diff: 5760967, time diff(ms): 5001
Statistics: 1126356.40 IOPS, diff: 5631782, time diff(ms): 5000
Statistics: 1126461.31 IOPS, diff: 5633433, time diff(ms): 5001
Statistics: 1128071.59 IOPS, diff: 5641486, time diff(ms): 5001
Statistics: 1126013.60 IOPS, diff: 5630068, time diff(ms): 5000
Statistics: 1126457.00 IOPS, diff: 5632285, time diff(ms): 5000
Statistics: 1126983.20 IOPS, diff: 5636043, time diff(ms): 5001


Modified (8 server cores)
Statistics: 2390920.62 IOPS, diff: 11956994, time diff(ms): 5001
Statistics: 2392582.08 IOPS, diff: 11965303, time diff(ms): 5001
Statistics: 2387272.00 IOPS, diff: 11936360, time diff(ms): 5000
Statistics: 2389885.22 IOPS, diff: 11951816, time diff(ms): 5001
Statistics: 2392866.00 IOPS, diff: 11964330, time diff(ms): 5000
Statistics: 2386649.67 IOPS, diff: 11935635, time diff(ms): 5001
Statistics: 2387749.60 IOPS, diff: 11938748, time diff(ms): 5000
Statistics: 2387559.69 IOPS, diff: 11940186, time diff(ms): 5001
Statistics: 2383972.20 IOPS, diff: 11919861, time diff(ms): 5000
Statistics: 2385133.37 IOPS, diff: 11928052, time diff(ms): 5001
