### PR TITLE
Expose ibv_context->num_comp_vectors

### DIFF
--- a/libdisni/src/verbs/com_ibm_disni_rdma_verbs_impl_NativeDispatcher.cpp
+++ b/libdisni/src/verbs/com_ibm_disni_rdma_verbs_impl_NativeDispatcher.cpp
@@ -49,7 +49,7 @@ using namespace std;
 //#define MAX_WR 200;
 #define MAX_SGE 4;
 //#define N_CQE 200
-#define JVERBS_JNI_VERSION 31;
+#define JVERBS_JNI_VERSION 32;
 
 //global resource id counter
 static unsigned long long counter = 0;
@@ -1168,6 +1168,28 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1get
         }
 
         return cmd_fd;
+}
+
+/*
+ * Class:     com_ibm_disni_rdma_verbs_impl_nat_NativeDispatcher
+ * Method:    _getContextNumCompVectors
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1getContextNumCompVectors
+  (JNIEnv *env, jobject obj, jlong obj_id) {
+    jint num_comp_vectors = -1;
+
+    pthread_rwlock_rdlock(&mut_context);
+    struct ibv_context *context = map_context[obj_id];
+    pthread_rwlock_unlock(&mut_context);
+    if (context != NULL) {
+        num_comp_vectors = context->num_comp_vectors;
+        log("j2c::getContextNumCompVectors: obj_id %llu, num_comp_vectors %i\n", obj_id, num_comp_vectors);
+    } else {
+        log("j2c::getContextNumCompVectors: failed, obj_id %llu\n", obj_id);
+    }
+
+    return num_comp_vectors;
 }
 
 /*

--- a/libdisni/src/verbs/com_ibm_disni_rdma_verbs_impl_NativeDispatcher.h
+++ b/libdisni/src/verbs/com_ibm_disni_rdma_verbs_impl_NativeDispatcher.h
@@ -297,6 +297,14 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1get
 
 /*
  * Class:     com_ibm_disni_verbs_impl_NativeDispatcher
+ * Method:    _getContextNumCompVectors
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_ibm_disni_rdma_verbs_impl_NativeDispatcher__1getContextNumCompVectors
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_ibm_disni_verbs_impl_NativeDispatcher
  * Method:    _getPdHandle
  * Signature: (J)I
  */

--- a/src/main/java/com/ibm/disni/rdma/verbs/IbvContext.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/IbvContext.java
@@ -40,10 +40,12 @@ import java.io.IOException;
 public class IbvContext  {
 	private RdmaVerbs verbs;
 	protected int cmd_fd;
+	protected int numCompVectors;
 	
-	protected IbvContext(int cmd_fd) throws IOException{
+	protected IbvContext(int cmd_fd, int numCompVectors) throws IOException {
 		this.verbs = RdmaVerbs.open();
 		this.cmd_fd = cmd_fd;
+		this.numCompVectors = numCompVectors;
 	}
 
 	/**
@@ -53,6 +55,10 @@ public class IbvContext  {
 	 */
 	public int getCmd_fd() {
 		return cmd_fd;
+	}
+
+	public int getNumCompVectors() {
+		return numCompVectors;
 	}
 	
 	//---------- oo-verbs

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatIbvContext.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatIbvContext.java
@@ -30,7 +30,7 @@ public class NatIbvContext extends IbvContext implements NatObject {
 	private NativeDispatcher nativeDispatcher;
 
 	public NatIbvContext(long objId, NativeDispatcher nativeDispatcher) throws IOException{
-		super(-1);
+		super(-1, -1);
 		this.objId = objId;
 		this.nativeDispatcher = nativeDispatcher;
 	}
@@ -45,5 +45,13 @@ public class NatIbvContext extends IbvContext implements NatObject {
 			this.cmd_fd = nativeDispatcher._getContextFd(objId);
 		}		
 		return super.getCmd_fd();
-	}	
+	}
+
+	@Override
+	public int getNumCompVectors() {
+		if (this.numCompVectors < 0){
+			this.numCompVectors = nativeDispatcher._getContextNumCompVectors(objId);
+		}
+		return super.getNumCompVectors();
+	}
 }

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NativeDispatcher.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NativeDispatcher.java
@@ -30,8 +30,8 @@ import com.ibm.disni.util.DiSNILogger;
 
 public class NativeDispatcher {
 	private static final Logger logger = DiSNILogger.getLogger();
-	private static int JVERBS_VERSION = 31;
-	
+	private static int JVERBS_VERSION = 32;
+
 	static {
 	    System.loadLibrary("disni");
 	}	
@@ -128,6 +128,7 @@ public class NativeDispatcher {
 	public native long _getContext(long id);
 	public native int _getQpNum(long id);
 	public native int _getContextFd(long objId);
+	public native int _getContextNumCompVectors(long objId);
 	public native int _getPdHandle(long objId);
 	
 	//struct verification


### PR DESCRIPTION
Added a getter function to libdisni: _getContextNumCompVectors - interface version incremented to 32
Exposing num_comp_vectors allows DiSNI consumers to check the maximum number of CPU vectors that is allowed to be used in ibv_create_cq().