### PR TITLE
Remove caching SVC objects.

### DIFF
--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatDeregMrCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatDeregMrCall.java
@@ -34,13 +34,9 @@ public class NatDeregMrCall extends SVCDeregMr {
 	private NatIbvMr mr;
 	private boolean valid;
 
-	public NatDeregMrCall(RdmaVerbsNat verbs, NativeDispatcher nativeDispatcher) {
+	public NatDeregMrCall(RdmaVerbsNat verbs, NativeDispatcher nativeDispatcher, IbvMr mr) {
 		this.verbs = verbs;
 		this.nativeDispatcher = nativeDispatcher;
-		this.valid = false;
-	}
-
-	public void set(IbvMr mr) {
 		this.mr = (NatIbvMr) mr;
 		this.valid = true;
 	}
@@ -62,7 +58,6 @@ public class NatDeregMrCall extends SVCDeregMr {
 	}
 
 	public SVCDeregMr free() {
-		verbs.free(this);
 		this.valid = false;
 		return this;
 	}

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPollCqCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPollCqCall.java
@@ -75,6 +75,7 @@ public class NatPollCqCall extends SVCPollCq {
 		
 		this.csize = wcList.length*IbvWC.CSIZE;
 		if (cmd != null){
+			assert cmd.size() >= csize;
 			cmd.getBuffer().clear();
 		} else {
 			this.cmd = memAlloc.allocate(csize);

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPollCqCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPollCqCall.java
@@ -61,26 +61,18 @@ public class NatPollCqCall extends SVCPollCq {
 	private int result;
 	private boolean valid;
 	
-	public NatPollCqCall(RdmaVerbsNat verbs, NativeDispatcher nativeDispatcher, MemoryAllocation memAlloc) {
+	public NatPollCqCall(RdmaVerbsNat verbs, NativeDispatcher nativeDispatcher,
+	                     MemoryAllocation memAlloc, IbvCQ cq, IbvWC[] wcList, int ne) {
 		this.verbs = verbs;
 		this.nativeDispatcher = nativeDispatcher;
 		this.memAlloc = memAlloc;
 		this.valid = false;
-	}
-
-	public void set(IbvCQ cq, IbvWC[] wcList, int ne) {
 		this.cq = (NatIbvCQ) cq;
 		this.wcList = wcList;
 		this.ne = ne;
-		
-		this.csize = wcList.length*IbvWC.CSIZE;
-		if (cmd != null){
-			assert cmd.size() >= csize;
-			cmd.getBuffer().clear();
-		} else {
-			this.cmd = memAlloc.allocate(csize);
-		}
 
+		this.csize = wcList.length*IbvWC.CSIZE;
+		this.cmd = memAlloc.allocate(csize);
 		this.valid = true;
 	}
 	
@@ -141,7 +133,6 @@ public class NatPollCqCall extends SVCPollCq {
 			cmd = null;
 		}		
 		this.valid = false;
-		verbs.free(this);
 		return this;
 	}
 }

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostRecvCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostRecvCall.java
@@ -79,6 +79,7 @@ public class NatPostRecvCall extends SVCPostRecv {
 			}
 		}
 		if (cmd != null){
+			assert cmd.size() >= size;
 			cmd.getBuffer().clear();
 		} else {
 			this.cmd = memAlloc.allocate(size);

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostSendCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostSendCall.java
@@ -86,6 +86,7 @@ public class NatPostSendCall extends SVCPostSend {
 		}
 
 		if (cmd != null){
+			assert cmd.size() >= size;
 			cmd.getBuffer().clear();
 		} else {
 			this.cmd = memAlloc.allocate(size);

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatReqNotifyCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatReqNotifyCall.java
@@ -36,13 +36,10 @@ public class NatReqNotifyCall extends SVCReqNotify {
 	private boolean valid;
 	
 	
-	public NatReqNotifyCall(RdmaVerbsNat verbs, NativeDispatcher nativeDispatcher) {
+	public NatReqNotifyCall(RdmaVerbsNat verbs, NativeDispatcher nativeDispatcher,
+							IbvCQ cq, boolean solicited_only) {
 		this.verbs = verbs;
 		this.nativeDispatcher = nativeDispatcher;
-		this.valid = false;
-	}
-
-	public void set(IbvCQ cq, boolean solicited_only) {
 		this.cq = (NatIbvCQ) cq;
 		this.solicited = solicited_only ? 1 : 0;
 		this.valid = true;
@@ -65,7 +62,6 @@ public class NatReqNotifyCall extends SVCReqNotify {
 
 	public SVCReqNotify free() {
 		this.valid = false;
-		verbs.free(this);
 		return this;
 	}
 

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/RdmaVerbsNat.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/RdmaVerbsNat.java
@@ -55,23 +55,9 @@ public class RdmaVerbsNat extends RdmaVerbs {
 	private MemoryAllocation memAlloc;
 	private NativeDispatcher nativeDispatcher;
 	
-	private LinkedBlockingQueue<NatRegMrCall> regList;
-	private LinkedBlockingQueue<NatDeregMrCall> deregList;
-	private LinkedBlockingQueue<NatPostSendCall> postSendList;
-	private LinkedBlockingQueue<NatPostRecvCall> postRecvList;
-	private LinkedBlockingQueue<NatPollCqCall> pollCqList;
-	private LinkedBlockingQueue<NatReqNotifyCall> reqNotifyList;
-	
 	public RdmaVerbsNat(NativeDispatcher nativeDispatcher) {
 		this.memAlloc = MemoryAllocation.getInstance();
 		this.nativeDispatcher = nativeDispatcher;
-		
-		this.regList = new LinkedBlockingQueue<NatRegMrCall>();
-		this.deregList = new LinkedBlockingQueue<NatDeregMrCall>();
-		this.postSendList = new LinkedBlockingQueue<NatPostSendCall>();
-		this.postRecvList = new LinkedBlockingQueue<NatPostRecvCall>();
-		this.pollCqList = new LinkedBlockingQueue<NatPollCqCall>();
-		this.reqNotifyList = new LinkedBlockingQueue<NatReqNotifyCall>();
 	}
 
 	public IbvPd allocPd(IbvContext context) throws IOException {
@@ -142,20 +128,14 @@ public class RdmaVerbsNat extends RdmaVerbs {
 		return null;
 	}
 
-	public SVCRegMr regMr(IbvPd pd, ByteBuffer buffer, int access) throws IOException {
-		NatRegMrCall regMrCall = regList.poll();
-		if (regMrCall == null){
-			regMrCall = new NatRegMrCall(this, nativeDispatcher, memAlloc);
-		}
+	public SVCRegMr regMr(IbvPd pd, ByteBuffer buffer, int access) {
+		NatRegMrCall regMrCall =  new NatRegMrCall(this, nativeDispatcher, memAlloc);
 		regMrCall.set(pd, buffer, access);
 		return regMrCall;
 	}
 
-	public SVCRegMr regMr(IbvPd pd, long address, int length, int access) throws IOException {
-		NatRegMrCall regMrCall = regList.poll();
-		if (regMrCall == null){
-			regMrCall = new NatRegMrCall(this, nativeDispatcher, memAlloc);
-		}
+	public SVCRegMr regMr(IbvPd pd, long address, int length, int access) {
+		NatRegMrCall regMrCall = new NatRegMrCall(this, nativeDispatcher, memAlloc);
 		regMrCall.set(pd, address, length, access);
 		return regMrCall;
 
@@ -172,30 +152,20 @@ public class RdmaVerbsNat extends RdmaVerbs {
 
 	public SVCDeregMr deregMr(IbvMr mr)
 			throws IOException {
-		NatDeregMrCall deregMrCall = deregList.poll();
-		if (deregMrCall == null){
-			deregMrCall = new NatDeregMrCall(this, nativeDispatcher);
-		}
+		NatDeregMrCall deregMrCall = new NatDeregMrCall(this, nativeDispatcher);
 		deregMrCall.set(mr);
 		return deregMrCall;
 	}
 
-	public SVCPostSend postSend(IbvQP qp,
-			List<IbvSendWR> wrList, List<IbvSendWR> badwrList) throws IOException {
-		NatPostSendCall postSendCall = postSendList.poll();
-		if (postSendCall == null) {
-			postSendCall = new NatPostSendCall(this, nativeDispatcher,
-					memAlloc);
-		}
+	public SVCPostSend postSend(IbvQP qp, List<IbvSendWR> wrList, List<IbvSendWR> badwrList) {
+		NatPostSendCall postSendCall = new NatPostSendCall(this, nativeDispatcher,
+			    memAlloc);
 		postSendCall.set(qp, wrList);
 		return postSendCall;
 	}
 
-	public SVCPostRecv postRecv(IbvQP qp, List<IbvRecvWR> wrList, List<IbvRecvWR> badwrList) throws IOException {
-		NatPostRecvCall postRecvCall = postRecvList.poll();
-		if (postRecvCall == null){
-			postRecvCall = new NatPostRecvCall(this, nativeDispatcher, memAlloc);
-		}
+	public SVCPostRecv postRecv(IbvQP qp, List<IbvRecvWR> wrList, List<IbvRecvWR> badwrList) {
+		NatPostRecvCall postRecvCall = new NatPostRecvCall(this, nativeDispatcher, memAlloc);
 		postRecvCall.set(qp, wrList);
 		return postRecvCall;
 	}
@@ -209,21 +179,14 @@ public class RdmaVerbsNat extends RdmaVerbs {
 		return ret >= 0 ? true : false;
 	}
 
-	public SVCPollCq pollCQ(IbvCQ cq, IbvWC[] wcList, int ne) throws IOException {
-		NatPollCqCall pollCqCall = pollCqList.poll();
-		if (pollCqCall == null){
-			pollCqCall = new NatPollCqCall(this, nativeDispatcher, memAlloc);
-		}
+	public SVCPollCq pollCQ(IbvCQ cq, IbvWC[] wcList, int ne) {
+		NatPollCqCall pollCqCall = new NatPollCqCall(this, nativeDispatcher, memAlloc);
 		pollCqCall.set(cq, wcList, ne);
 		return pollCqCall;
 	}
 
-	public SVCReqNotify reqNotifyCQ(IbvCQ cq,
-			boolean solicited_only) throws IOException {
-		NatReqNotifyCall reqNotifyCall = reqNotifyList.poll();
-		if (reqNotifyCall == null){
-			reqNotifyCall = new NatReqNotifyCall(this, nativeDispatcher);
-		}
+	public SVCReqNotify reqNotifyCQ(IbvCQ cq, boolean solicited_only) {
+		NatReqNotifyCall reqNotifyCall = new NatReqNotifyCall(this, nativeDispatcher);
 		reqNotifyCall.set(cq, solicited_only);
 		return reqNotifyCall;
 	}
@@ -275,26 +238,25 @@ public class RdmaVerbsNat extends RdmaVerbs {
 	//--------------------------------------
 
 	void free(NatRegMrCall natRegMrCall) {
-		this.regList.add(natRegMrCall);
 	}
 
 	public void free(NatDeregMrCall natDeregMrCall) {
-		this.deregList.add(natDeregMrCall);
+
 	}
 
 	public void free(NatPostSendCall natPostSendCall) {
-		this.postSendList.add(natPostSendCall);
+
 	}
 
 	public void free(NatPostRecvCall natPostRecvCall) {
-		this.postRecvList.add(natPostRecvCall);
+
 	}
 
 	public void free(NatPollCqCall natPollCqCall) {
-		this.pollCqList.add(natPollCqCall);
+
 	}
 
 	public void free(NatReqNotifyCall natReqNotifyCall) {
-		this.reqNotifyList.add(natReqNotifyCall);
+
 	}
 }

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/RdmaVerbsNat.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/RdmaVerbsNat.java
@@ -129,15 +129,11 @@ public class RdmaVerbsNat extends RdmaVerbs {
 	}
 
 	public SVCRegMr regMr(IbvPd pd, ByteBuffer buffer, int access) {
-		NatRegMrCall regMrCall =  new NatRegMrCall(this, nativeDispatcher, memAlloc);
-		regMrCall.set(pd, buffer, access);
-		return regMrCall;
+		return new NatRegMrCall(this, nativeDispatcher, memAlloc, pd, buffer, access);
 	}
 
 	public SVCRegMr regMr(IbvPd pd, long address, int length, int access) {
-		NatRegMrCall regMrCall = new NatRegMrCall(this, nativeDispatcher, memAlloc);
-		regMrCall.set(pd, address, length, access);
-		return regMrCall;
+		return new NatRegMrCall(this, nativeDispatcher, memAlloc, pd, address, length, access);
 
 	}
 
@@ -152,22 +148,15 @@ public class RdmaVerbsNat extends RdmaVerbs {
 
 	public SVCDeregMr deregMr(IbvMr mr)
 			throws IOException {
-		NatDeregMrCall deregMrCall = new NatDeregMrCall(this, nativeDispatcher);
-		deregMrCall.set(mr);
-		return deregMrCall;
+		return new NatDeregMrCall(this, nativeDispatcher, mr);
 	}
 
 	public SVCPostSend postSend(IbvQP qp, List<IbvSendWR> wrList, List<IbvSendWR> badwrList) {
-		NatPostSendCall postSendCall = new NatPostSendCall(this, nativeDispatcher,
-			    memAlloc);
-		postSendCall.set(qp, wrList);
-		return postSendCall;
+		return new NatPostSendCall(this, nativeDispatcher, memAlloc, qp, wrList);
 	}
 
 	public SVCPostRecv postRecv(IbvQP qp, List<IbvRecvWR> wrList, List<IbvRecvWR> badwrList) {
-		NatPostRecvCall postRecvCall = new NatPostRecvCall(this, nativeDispatcher, memAlloc);
-		postRecvCall.set(qp, wrList);
-		return postRecvCall;
+		return new NatPostRecvCall(this, nativeDispatcher, memAlloc, qp, wrList);
 	}
 
 	public boolean getCqEvent(IbvCompChannel compChannel, IbvCQ cq, int timeout) throws IOException {
@@ -180,15 +169,11 @@ public class RdmaVerbsNat extends RdmaVerbs {
 	}
 
 	public SVCPollCq pollCQ(IbvCQ cq, IbvWC[] wcList, int ne) {
-		NatPollCqCall pollCqCall = new NatPollCqCall(this, nativeDispatcher, memAlloc);
-		pollCqCall.set(cq, wcList, ne);
-		return pollCqCall;
+		return new NatPollCqCall(this, nativeDispatcher, memAlloc, cq, wcList, ne);
 	}
 
 	public SVCReqNotify reqNotifyCQ(IbvCQ cq, boolean solicited_only) {
-		NatReqNotifyCall reqNotifyCall = new NatReqNotifyCall(this, nativeDispatcher);
-		reqNotifyCall.set(cq, solicited_only);
-		return reqNotifyCall;
+		return new NatReqNotifyCall(this, nativeDispatcher, cq, solicited_only);
 	}
 
 	public int ackCqEvents(IbvCQ cq, int nevents) throws IOException {
@@ -233,30 +218,5 @@ public class RdmaVerbsNat extends RdmaVerbs {
 		cqImpl.close();
 		int ret = nativeDispatcher._destroyCQ(cqImpl.getObjId());
 		return ret;
-	}
-	
-	//--------------------------------------
-
-	void free(NatRegMrCall natRegMrCall) {
-	}
-
-	public void free(NatDeregMrCall natDeregMrCall) {
-
-	}
-
-	public void free(NatPostSendCall natPostSendCall) {
-
-	}
-
-	public void free(NatPostRecvCall natPostRecvCall) {
-
-	}
-
-	public void free(NatPollCqCall natPollCqCall) {
-
-	}
-
-	public void free(NatReqNotifyCall natReqNotifyCall) {
-
 	}
 }

--- a/src/main/java/com/ibm/disni/util/MemoryAllocation.java
+++ b/src/main/java/com/ibm/disni/util/MemoryAllocation.java
@@ -38,7 +38,7 @@ public class MemoryAllocation {
 	}
 	
 	private MemoryAllocation() {
-		table = new ConcurrentSkipListMap<>();
+		table = new ConcurrentSkipListMap<Integer, MemBuf>();
 	}
 
 	private int roundUpSize(int size){


### PR DESCRIPTION
@patrickstuedi as discussed in previous PR. 
Constructor of SVC objects takes nothing compared to accessing synchronized concurrent collections.
All the caching logic could be done on application side, just need to make sure that it doesn't tries to set bigger WR list than in cached object.