### PR TITLE
PingPong test with TCP vs RDMA modes.

### DIFF
--- a/src/test/java/com/ibm/disni/benchmarks/RDMAvsTcpBenchmarkClient.java
+++ b/src/test/java/com/ibm/disni/benchmarks/RDMAvsTcpBenchmarkClient.java
@@ -1,0 +1,149 @@
+/*
+ * DiSNI: Direct Storage and Networking Interface
+ *
+ * Author: Peter Rudenko <peterr@mellanox.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ibm.disni.benchmarks;
+
+import com.ibm.disni.examples.SendRecvClient.CustomClientEndpoint;
+import com.ibm.disni.rdma.RdmaActiveEndpointGroup;
+import com.ibm.disni.rdma.RdmaEndpointFactory;
+import com.ibm.disni.rdma.verbs.*;
+import org.apache.commons.cli.ParseException;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+
+public class RDMAvsTcpBenchmarkClient implements RdmaEndpointFactory<CustomClientEndpoint> {
+  RdmaActiveEndpointGroup<CustomClientEndpoint> endpointGroup;
+  private InetSocketAddress rdmaAddress;
+  private InetSocketAddress tcpAddress;
+  private int bufferSize;
+  private int loopCount;
+
+  public CustomClientEndpoint createEndpoint(RdmaCmId idPriv, boolean serverSide) throws IOException {
+    return new CustomClientEndpoint(endpointGroup, idPriv, serverSide, bufferSize);
+  }
+
+  public void runTCP() throws Exception {
+    SocketChannel socketChannel = SocketChannel.open(tcpAddress);
+    socketChannel.configureBlocking(true);
+    socketChannel.socket().setReceiveBufferSize(bufferSize);
+    socketChannel.socket().setSendBufferSize(bufferSize);
+    ByteBuffer sendBuf = ByteBuffer.allocateDirect(bufferSize);
+    ByteBuffer recvBuf = ByteBuffer.allocateDirect(bufferSize);
+    sendBuf.asCharBuffer().put("PING").clear();
+    long startTime = System.nanoTime();
+    for (int i = 0; i < loopCount; i++){
+      int read = 0;
+      int written = 0;
+
+      // Send PING
+      sendBuf.clear();
+      do {
+        written += socketChannel.write(sendBuf);
+      } while (written != bufferSize);
+
+      // Recv PONG
+      do {
+        read += socketChannel.read(recvBuf);
+      } while (read != bufferSize);
+      recvBuf.clear();
+    }
+    System.out.println("TCP result:");
+    printResults(startTime);
+    socketChannel.close();
+  }
+
+  public void runRDMA() throws Exception {
+    //create a EndpointGroup. The RdmaActiveEndpointGroup contains CQ processing and delivers CQ event to the endpoint.dispatchCqEvent() method.
+    endpointGroup = new RdmaActiveEndpointGroup<CustomClientEndpoint>(1000, false, 128, 4, 128);
+    endpointGroup.init(this);
+    //we have passed our own endpoint factory to the group, therefore new endpoints will be of type CustomClientEndpoint
+    //let's create a new client endpoint
+    CustomClientEndpoint endpoint = endpointGroup.createEndpoint();
+
+    //connect to the server
+    endpoint.connect(rdmaAddress, 1000);
+    System.out.println("RDMAvsTcpBenchmarkClient::client channel set up ");
+
+    //in our custom endpoints we have prepared (memory registration and work request creation) some memory
+    //buffers beforehand.
+    //let's send one of those buffers out using a send operation
+    ByteBuffer sendBuf = endpoint.getSendBuf();
+    ByteBuffer recvBuf = endpoint.getRecvBuf();
+    sendBuf.asCharBuffer().put("PING");
+    SVCPostSend postSend = endpoint.postSend(endpoint.getWrList_send());
+    SVCPostRecv postRecv = endpoint.postRecv(endpoint.getWrList_recv());
+    long startTime = System.nanoTime();
+    for (int i = 0; i < loopCount + 1; i++) {
+      // Send PING
+      sendBuf.clear();
+      postSend.execute();
+      endpoint.getWcEvents().take();
+
+      // Recv PONG
+      postRecv.execute();
+      endpoint.getWcEvents().take();
+      recvBuf.clear();
+    }
+    System.out.println("RDMA result:");
+    printResults(startTime);
+    //close everything
+    endpoint.close();
+    endpointGroup.close();
+  }
+
+  private void printResults(long startTime){
+    long duration = System.nanoTime() - startTime;
+    long totalSize = (long)bufferSize * 2 * loopCount;
+    System.out.println("Total time: " + duration / 1e6 + " ms");
+    System.out.println("Bidirectional bandwidth: " + totalSize * 1e9/1024/1024/1024/duration + " Gb/s");
+    System.out.println("Bidirectional average latency: " + duration  / (1e6 * loopCount) + " ms");
+  }
+
+  public void launch(String[] args) throws Exception {
+    RdmaBenchmarkCmdLine cmdLine = new RdmaBenchmarkCmdLine("RDMAvsTcpBenchmarkClient");
+
+    try {
+      cmdLine.parse(args);
+    } catch (ParseException e) {
+      cmdLine.printHelp();
+      System.exit(-1);
+    }
+    String host = cmdLine.getIp();
+    Integer port = cmdLine.getPort();
+
+    InetAddress ipAddress = InetAddress.getByName(host);
+    rdmaAddress = new InetSocketAddress(ipAddress, port);
+    tcpAddress = new InetSocketAddress(ipAddress, port + 1);
+    bufferSize = cmdLine.getSize();
+    loopCount = cmdLine.getLoop();
+
+    this.runRDMA();
+    this.runTCP();
+    System.exit(0);
+  }
+
+  public static void main(String[] args) throws Exception {
+    RDMAvsTcpBenchmarkClient pingPongClient = new RDMAvsTcpBenchmarkClient();
+    pingPongClient.launch(args);
+  }
+}
+

--- a/src/test/java/com/ibm/disni/benchmarks/RDMAvsTcpBenchmarkServer.java
+++ b/src/test/java/com/ibm/disni/benchmarks/RDMAvsTcpBenchmarkServer.java
@@ -1,0 +1,154 @@
+/*
+ * DiSNI: Direct Storage and Networking Interface
+ *
+ * Author: Peter Rudenko <peterr@mellanox.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.ibm.disni.benchmarks;
+
+import com.ibm.disni.examples.SendRecvServer;
+import com.ibm.disni.rdma.RdmaActiveEndpointGroup;
+import com.ibm.disni.rdma.RdmaEndpointFactory;
+import com.ibm.disni.rdma.RdmaServerEndpoint;
+import com.ibm.disni.rdma.verbs.RdmaCmId;
+import com.ibm.disni.rdma.verbs.SVCPostRecv;
+import com.ibm.disni.rdma.verbs.SVCPostSend;
+import org.apache.commons.cli.ParseException;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+
+public class RDMAvsTcpBenchmarkServer implements RdmaEndpointFactory<SendRecvServer.CustomServerEndpoint> {
+  RdmaActiveEndpointGroup<SendRecvServer.CustomServerEndpoint> endpointGroup;
+  private int bufferSize;
+  private int loopCount;
+  private RdmaServerEndpoint<SendRecvServer.CustomServerEndpoint> serverEndpoint;
+  private ServerSocketChannel serverSocket;
+
+  @Override
+  public SendRecvServer.CustomServerEndpoint createEndpoint(RdmaCmId id, boolean serverSide) throws IOException {
+    return new SendRecvServer.CustomServerEndpoint(endpointGroup, id, serverSide, bufferSize);
+  }
+
+
+  public void runTCP() throws Exception {
+
+    ByteBuffer sendBuf = ByteBuffer.allocateDirect(bufferSize);
+    ByteBuffer recvBuf = ByteBuffer.allocateDirect(bufferSize);
+    sendBuf.asCharBuffer().put("PONG").clear();
+    SocketChannel socketChannel = serverSocket.accept();
+    socketChannel.configureBlocking(true);
+    socketChannel.socket().setSendBufferSize(bufferSize);
+    socketChannel.socket().setReceiveBufferSize(bufferSize);
+    System.out.println("Accepted connection from " + socketChannel.getRemoteAddress());
+    for (int i = 0; i < loopCount; i++) {
+      int read = 0;
+      int written = 0;
+
+      // Recv PING
+      recvBuf.clear();
+      do {
+        read += socketChannel.read(recvBuf);
+      } while (read != bufferSize);
+
+      //Send PONG
+      sendBuf.clear();
+      do {
+        written += socketChannel.write(sendBuf);
+      } while (written != bufferSize);
+
+    }
+    socketChannel.close();
+    serverSocket.close();
+  }
+
+  public void runRDMA() throws Exception {
+    //we can accept new connections
+    SendRecvServer.CustomServerEndpoint clientEndpoint = serverEndpoint.accept();
+    //we have previously passed our own endpoint factory to the group, therefore new endpoints will be of type CustomServerEndpoint
+    System.out.println("RDMAvsTcpBenchmarkServer::client connection accepted");
+    //in our custom endpoints we have prepared (memory registration and work request creation) some memory buffers beforehand.
+    ByteBuffer sendBuf = clientEndpoint.getSendBuf();
+
+    sendBuf.asCharBuffer().put("PONG");
+    ByteBuffer recvBuf = clientEndpoint.getRecvBuf();
+    SVCPostSend postSend = clientEndpoint.postSend(clientEndpoint.getWrList_send());
+    SVCPostRecv postRecv = clientEndpoint.postRecv(clientEndpoint.getWrList_recv());
+    for (int i = 0; i < loopCount + 1; i++){
+      // Recv PING
+      postRecv.execute();
+      clientEndpoint.getWcEvents().take();
+      recvBuf.clear();
+
+      //Send PONG
+      postSend.execute();
+      clientEndpoint.getWcEvents().take();
+      sendBuf.clear();
+    }
+    clientEndpoint.close();
+    serverEndpoint.close();
+    endpointGroup.close();
+  }
+
+
+  public void launch(String[] args) throws Exception {
+    RdmaBenchmarkCmdLine cmdLine = new RdmaBenchmarkCmdLine("RDMAvsTcpBenchmarkServer");
+
+    try {
+      cmdLine.parse(args);
+    } catch (ParseException e) {
+      cmdLine.printHelp();
+      System.exit(-1);
+    }
+    String host = cmdLine.getIp();
+    Integer port = cmdLine.getPort();
+    System.out.println("Address: " + host + ":" + port);
+    InetAddress ipAddress = InetAddress.getByName(host);
+    InetSocketAddress rdmaAddress = new InetSocketAddress(ipAddress, port);
+    bufferSize = cmdLine.getSize();
+    System.out.println("Buffer size: " + bufferSize);
+    loopCount = cmdLine.getLoop();
+
+    // Start RDMA Server
+    //create a EndpointGroup. The RdmaActiveEndpointGroup contains CQ processing and delivers CQ event to the endpoint.dispatchCqEvent() method.
+    endpointGroup = new RdmaActiveEndpointGroup<SendRecvServer.CustomServerEndpoint>(1000, false, 128, 4, 128);
+    endpointGroup.init(this);
+    //create a server endpoint
+    serverEndpoint = endpointGroup.createServerEndpoint();
+
+    serverEndpoint.bind(rdmaAddress, 10);
+    System.out.println("RdmaVsTcpBenchmarkServer bound to address " + rdmaAddress.toString());
+
+    // Start TCP Server
+    InetSocketAddress tcpAddress = new InetSocketAddress(host, port + 1);
+    serverSocket = ServerSocketChannel.open();
+    serverSocket.socket().bind(tcpAddress);
+    serverSocket.socket().setReceiveBufferSize(bufferSize);
+    System.out.println("TCP server listening " + tcpAddress);
+
+    this.runRDMA();
+    this.runTCP();
+    System.exit(0);
+  }
+
+  public static void main(String[] args) throws Exception {
+    RDMAvsTcpBenchmarkServer pingPongServer = new RDMAvsTcpBenchmarkServer();
+    pingPongServer.launch(args);
+  }
+}

--- a/src/test/java/com/ibm/disni/benchmarks/SendRecvClient.java
+++ b/src/test/java/com/ibm/disni/benchmarks/SendRecvClient.java
@@ -88,7 +88,7 @@ public class SendRecvClient implements RdmaEndpointFactory<SendRecvClient.SendRe
 		double _seconds = _duration / 1000 / 1000 / 1000;
 		double iops = _ops / _seconds;
 		System.out.println("iops " + iops);
-
+		System.out.println("Bidirectional average latency: " + duration  / (1e6 * loop) + " ms");
 
 		//close everything
 		endpoint.close();

--- a/src/test/java/com/ibm/disni/benchmarks/SendRecvServer.java
+++ b/src/test/java/com/ibm/disni/benchmarks/SendRecvServer.java
@@ -64,7 +64,7 @@ public class SendRecvServer implements RdmaEndpointFactory<SendRecvServer.SendRe
 
 		RdmaServerEndpoint<SendRecvServer.SendRecvEndpoint> serverEndpoint = group.createServerEndpoint();
 		InetAddress ipAddress = InetAddress.getByName(host);
-		InetSocketAddress address = new InetSocketAddress(ipAddress, 1919);				
+		InetSocketAddress address = new InetSocketAddress(ipAddress, port);
 		serverEndpoint.bind(address, 10);
 		SendRecvServer.SendRecvEndpoint endpoint = serverEndpoint.accept();
 		System.out.println("SendRecvServer, client connected, address " + address.toString());

--- a/src/test/java/com/ibm/disni/examples/SendRecvClient.java
+++ b/src/test/java/com/ibm/disni/examples/SendRecvClient.java
@@ -42,7 +42,7 @@ public class SendRecvClient implements RdmaEndpointFactory<SendRecvClient.Custom
 	private int port;
 
 	public SendRecvClient.CustomClientEndpoint createEndpoint(RdmaCmId idPriv, boolean serverSide) throws IOException {
-		return new CustomClientEndpoint(endpointGroup, idPriv, serverSide);
+		return new CustomClientEndpoint(endpointGroup, idPriv, serverSide, 100);
 	}
 
 	public void run() throws Exception {
@@ -113,7 +113,6 @@ public class SendRecvClient implements RdmaEndpointFactory<SendRecvClient.Custom
 		private ByteBuffer buffers[];
 		private IbvMr mrlist[];
 		private int buffercount = 3;
-		private int buffersize = 100;
 
 		private ByteBuffer dataBuf;
 		private IbvMr dataMr;
@@ -134,10 +133,10 @@ public class SendRecvClient implements RdmaEndpointFactory<SendRecvClient.Custom
 
 		private ArrayBlockingQueue<IbvWC> wcEvents;
 
-		public CustomClientEndpoint(RdmaActiveEndpointGroup<CustomClientEndpoint> endpointGroup, RdmaCmId idPriv, boolean serverSide) throws IOException {
+		public CustomClientEndpoint(RdmaActiveEndpointGroup<CustomClientEndpoint> endpointGroup,
+	                                    RdmaCmId idPriv, boolean serverSide, int buffersize) throws IOException {
 			super(endpointGroup, idPriv, serverSide);
 			this.buffercount = 3;
-			this.buffersize = 100;
 			buffers = new ByteBuffer[buffercount];
 			this.mrlist = new IbvMr[buffercount];
 

--- a/src/test/java/com/ibm/disni/examples/SendRecvServer.java
+++ b/src/test/java/com/ibm/disni/examples/SendRecvServer.java
@@ -42,7 +42,7 @@ public class SendRecvServer implements RdmaEndpointFactory<SendRecvServer.Custom
 	private int port;
 
 	public SendRecvServer.CustomServerEndpoint createEndpoint(RdmaCmId idPriv, boolean serverSide) throws IOException {
-		return new SendRecvServer.CustomServerEndpoint(endpointGroup, idPriv, serverSide);
+		return new SendRecvServer.CustomServerEndpoint(endpointGroup, idPriv, serverSide, 100);
 	}
 
 	public void run() throws Exception {
@@ -115,7 +115,6 @@ public class SendRecvServer implements RdmaEndpointFactory<SendRecvServer.Custom
 		private ByteBuffer buffers[];
 		private IbvMr mrlist[];
 		private int buffercount = 3;
-		private int buffersize = 100;
 
 		private ByteBuffer dataBuf;
 		private IbvMr dataMr;
@@ -136,10 +135,10 @@ public class SendRecvServer implements RdmaEndpointFactory<SendRecvServer.Custom
 
 		private ArrayBlockingQueue<IbvWC> wcEvents;
 
-		public CustomServerEndpoint(RdmaActiveEndpointGroup<CustomServerEndpoint> endpointGroup, RdmaCmId idPriv, boolean serverSide) throws IOException {
+		public CustomServerEndpoint(RdmaActiveEndpointGroup<CustomServerEndpoint> endpointGroup,
+		                            RdmaCmId idPriv, boolean serverSide, int buffersize) throws IOException {
 			super(endpointGroup, idPriv, serverSide);
 			this.buffercount = 3;
-			this.buffersize = 100;
 			buffers = new ByteBuffer[buffercount];
 			this.mrlist = new IbvMr[buffercount];
 


### PR DESCRIPTION
PingPong test inspiried by [RDMA perftest](https://github.com/linux-rdma/perftest) ib_send_lat with 2 modes: RDMA, TCP. Parameters the same as in SendRecv benchmark tests, with new additional argument: `-m rdma|tcp`.

CC @yuvaldeg 