### PR TITLE
[Proposal] Improve logging in libdisni

### DIFF
--- a/libdisni/configure.ac
+++ b/libdisni/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 #AC_PREREQ([2.67])
-AC_INIT([libdisni], [1.5], [https://github.com/zrlio/disni/issues])
+AC_INIT([libdisni], [1.9], [https://github.com/zrlio/disni/issues])
 AC_CONFIG_SRCDIR([src/verbs/com_ibm_disni_verbs_impl_NativeDispatcher.cpp])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/libdisni/src/verbs/com_ibm_disni_verbs_impl_NativeDispatcher.h
+++ b/libdisni/src/verbs/com_ibm_disni_verbs_impl_NativeDispatcher.h
@@ -41,7 +41,7 @@ Java_com_ibm_disni_verbs_impl_NativeDispatcher__1createQP(JNIEnv *, jobject,
  * Method:    _bindAddr
  * Signature: (JJ)I
  */
-JNIEXPORT jint JNICALL
+JNIEXPORT void JNICALL
 Java_com_ibm_disni_verbs_impl_NativeDispatcher__1bindAddr(JNIEnv *, jobject,
                                                           jlong, jlong);
 
@@ -50,7 +50,7 @@ Java_com_ibm_disni_verbs_impl_NativeDispatcher__1bindAddr(JNIEnv *, jobject,
  * Method:    _listen
  * Signature: (JI)I
  */
-JNIEXPORT jint JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1listen(
+JNIEXPORT void JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1listen(
     JNIEnv *, jobject, jlong, jint);
 
 /*
@@ -58,7 +58,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1listen(
  * Method:    _resolveAddr
  * Signature: (JJJI)I
  */
-JNIEXPORT jint JNICALL
+JNIEXPORT void JNICALL
 Java_com_ibm_disni_verbs_impl_NativeDispatcher__1resolveAddr(JNIEnv *, jobject,
                                                              jlong, jlong,
                                                              jlong, jint);
@@ -68,7 +68,7 @@ Java_com_ibm_disni_verbs_impl_NativeDispatcher__1resolveAddr(JNIEnv *, jobject,
  * Method:    _resolveRoute
  * Signature: (JI)I
  */
-JNIEXPORT jint JNICALL
+JNIEXPORT void JNICALL
 Java_com_ibm_disni_verbs_impl_NativeDispatcher__1resolveRoute(JNIEnv *, jobject,
                                                               jlong, jint);
 
@@ -87,7 +87,7 @@ Java_com_ibm_disni_verbs_impl_NativeDispatcher__1getCmEvent(JNIEnv *, jobject,
  * Method:    _connect
  * Signature: (JIIJB)I
  */
-JNIEXPORT jint JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1connect(
+JNIEXPORT void JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1connect(
     JNIEnv *, jobject, jlong, jint, jint, jlong, jbyte);
 
 /*
@@ -95,7 +95,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1connect(
  * Method:    _accept
  * Signature: (JII)I
  */
-JNIEXPORT jint JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1accept(
+JNIEXPORT void JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1accept(
     JNIEnv *, jobject, jlong, jint, jint);
 
 /*
@@ -205,7 +205,7 @@ Java_com_ibm_disni_verbs_impl_NativeDispatcher__1createCQ(JNIEnv *, jobject,
  * Method:    _modifyQP
  * Signature: (JJ)I
  */
-JNIEXPORT jint JNICALL
+JNIEXPORT void JNICALL
 Java_com_ibm_disni_verbs_impl_NativeDispatcher__1modifyQP(JNIEnv *, jobject,
                                                           jlong, jlong);
 
@@ -242,7 +242,7 @@ JNIEXPORT jlong JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1regMr(
  * Method:    _deregMr
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1deregMr(
+JNIEXPORT void JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1deregMr(
     JNIEnv *, jobject, jlong);
 
 /*
@@ -250,7 +250,7 @@ JNIEXPORT jint JNICALL Java_com_ibm_disni_verbs_impl_NativeDispatcher__1deregMr(
  * Method:    _postSend
  * Signature: (JJ)I
  */
-JNIEXPORT jint JNICALL
+JNIEXPORT void JNICALL
 Java_com_ibm_disni_verbs_impl_NativeDispatcher__1postSend(JNIEnv *, jobject,
                                                           jlong, jlong);
 
@@ -259,7 +259,7 @@ Java_com_ibm_disni_verbs_impl_NativeDispatcher__1postSend(JNIEnv *, jobject,
  * Method:    _postRecv
  * Signature: (JJ)I
  */
-JNIEXPORT jint JNICALL
+JNIEXPORT void JNICALL
 Java_com_ibm_disni_verbs_impl_NativeDispatcher__1postRecv(JNIEnv *, jobject,
                                                           jlong, jlong);
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.ibm.disni</groupId>
   <artifactId>disni</artifactId>
   <packaging>jar</packaging>
-  <version>1.8</version>
+  <version>1.9</version>
   <name>disni</name>
   <description>DiSNI (Direct Storage and Networking Interface) is a Java library for direct storage and networking access from userpace.</description>
   <url>http://github.com/zrlio/disni</url>

--- a/src/main/java/com/ibm/disni/RdmaServerEndpoint.java
+++ b/src/main/java/com/ibm/disni/RdmaServerEndpoint.java
@@ -78,13 +78,8 @@ public class RdmaServerEndpoint<C extends RdmaEndpoint> {
 			throw new IOException("endpoint has to be disconnected for bind");
 		}
 		connState = CONN_STATE_READY_FOR_ACCEPT;
-		
-		if (idPriv.bindAddr(src) != 0){
-			throw new IOException("binding server address " + src.toString() + ", failed");
-		}
-		if (idPriv.listen(backlog) != 0){
-			throw new IOException("listen to server address " + src.toString() + ", failed");
-		}
+		idPriv.bindAddr(src);
+		idPriv.listen(backlog);
 		this.pd = group.createProtectionDomainRaw(this);
 		logger.info("PD value " + pd.getHandle());
 		return this;

--- a/src/main/java/com/ibm/disni/verbs/IbvContext.java
+++ b/src/main/java/com/ibm/disni/verbs/IbvContext.java
@@ -75,7 +75,7 @@ public class IbvContext  {
 		return cmd_fd;
 	}
 
-	public int getNumCompVectors() {
+	public int getNumCompVectors() throws IOException {
 		return numCompVectors;
 	}
 	

--- a/src/main/java/com/ibm/disni/verbs/RdmaCm.java
+++ b/src/main/java/com/ibm/disni/verbs/RdmaCm.java
@@ -96,10 +96,9 @@ public abstract class RdmaCm {
 	 * 
 	 * @param id the RDMA identifier.
 	 * @param addr local address information.
-	 * @return returns 0 on success.
 	 * @throws Exception on failure.
 	 */
-	public abstract int bindAddr(RdmaCmId id, SocketAddress addr)
+	public abstract void bindAddr(RdmaCmId id, SocketAddress addr)
 			throws IOException;
 
 	/**
@@ -107,12 +106,11 @@ public abstract class RdmaCm {
 	 * 
 	 * The listen will be restricted to the locally bound source address.
 	 *
-	 * @param id the RDMA identifier. 
-	 * @param backlog the backlog of listen call. 
-	 * @return returns 0 on success. 
+	 * @param id the RDMA identifier.
+	 * @param backlog the backlog of listen call.
 	 * @throws Exception on failure. 
 	 */
-	public abstract int listen(RdmaCmId id, int backlog)
+	public abstract void listen(RdmaCmId id, int backlog)
 			throws IOException;
 
 	/**
@@ -121,14 +119,13 @@ public abstract class RdmaCm {
 	 * If successful, the specified RdmaCmId will be bound to a local device.
 	 *
 	 * @param id the RDMA identifier.
-	 * @param src source address information. 
+	 * @param src source address information.
 	 * @param dst destination address information
 	 * @param timeout time to wait for resolution to complete.
-	 * @return returns 0 on success. 
 	 * @throws Exception on failure.
 	 */
-	public abstract int resolveAddr(RdmaCmId id, SocketAddress src,
-			SocketAddress dst, int timeout) throws IOException;
+	public abstract void resolveAddr(RdmaCmId id, SocketAddress src,
+             SocketAddress dst, int timeout) throws IOException;
 
 	/**
 	 * Resolves an RDMA route to the destination address in order to establish a connection.
@@ -137,10 +134,9 @@ public abstract class RdmaCm {
 	 * 
 	 * @param id the RDMA identifier.
 	 * @param timeout time to wait for resolution to complete.
-	 * @return returns 0 on success. 
 	 * @throws Exception on failure.
 	 */
-	public abstract int resolveRoute(RdmaCmId id, int timeout)
+	public abstract void resolveRoute(RdmaCmId id, int timeout)
 			throws IOException;
 
 	/**
@@ -178,12 +174,11 @@ public abstract class RdmaCm {
 	 * 
 	 * flow_control: Specifies if hardware flow control is available. This value is exchanged with the remote peer and is not used to configure the QP. Applies only to RDMA_PS_TCP.
 	 *
-	 * @param id the RDMA identifier. 
+	 * @param id the RDMA identifier.
 	 * @param connParam connection parameters. See above for details.
-	 * @return returns 0 on success. 
 	 * @throws Exception on failure.
 	 */
-	public abstract int connect(RdmaCmId id, RdmaConnParam connParam)
+	public abstract void connect(RdmaCmId id, RdmaConnParam connParam)
 			throws IOException;
 
 	/**
@@ -210,10 +205,9 @@ public abstract class RdmaCm {
 	 *
 	 * @param id the connection identifier associated with the request
 	 * @param connParam Information needed to establish the connection. See above for details.
-	 * @return the int
 	 * @throws Exception the exception
 	 */
-	public abstract int accept(RdmaCmId id, RdmaConnParam connParam)
+	public abstract void accept(RdmaCmId id, RdmaConnParam connParam)
 			throws IOException;
 
 	/**

--- a/src/main/java/com/ibm/disni/verbs/RdmaCmId.java
+++ b/src/main/java/com/ibm/disni/verbs/RdmaCmId.java
@@ -131,28 +131,28 @@ public class RdmaCmId  {
 		return cm.createQP(this, pd, attr);
 	}
 	
-	public int bindAddr(SocketAddress addr) throws IOException{
-		return cm.bindAddr(this, addr);
+	public void bindAddr(SocketAddress addr) throws IOException{
+		cm.bindAddr(this, addr);
 	}
 	
-	public int listen(int backlog) throws IOException{
-		return cm.listen(this, backlog);
+	public void listen(int backlog) throws IOException{
+		cm.listen(this, backlog);
 	}	
 	
-	public int resolveAddr(SocketAddress src, SocketAddress dst, int timeout) throws IOException{
-		return cm.resolveAddr(this, src, dst, timeout);
+	public void resolveAddr(SocketAddress src, SocketAddress dst, int timeout) throws IOException{
+		cm.resolveAddr(this, src, dst, timeout);
 	}
 	
-	public int resolveRoute(int timeout) throws IOException{
-		return cm.resolveRoute(this, timeout);
+	public void resolveRoute(int timeout) throws IOException{
+		cm.resolveRoute(this, timeout);
 	}
 	
-	public int connect(RdmaConnParam connParam) throws IOException{
-		return cm.connect(this, connParam);
+	public void connect(RdmaConnParam connParam) throws IOException{
+		cm.connect(this, connParam);
 	}
 	
-	public int accept(RdmaConnParam connParam) throws IOException{
-		return cm.accept(this, connParam);
+	public void accept(RdmaConnParam connParam) throws IOException{
+		cm.accept(this, connParam);
 	}
 	
 	public int disconnect() throws IOException{

--- a/src/main/java/com/ibm/disni/verbs/impl/NatDeregMrCall.java
+++ b/src/main/java/com/ibm/disni/verbs/impl/NatDeregMrCall.java
@@ -46,10 +46,7 @@ public class NatDeregMrCall extends SVCDeregMr {
 			throw new IOException("Trying to deregister closed memory region.");
 		}
 		mr.close();
-		int ret = nativeDispatcher._deregMr(mr.getObjId());
-		if (ret != 0){
-			throw new IOException("Memory de-registration failed, ret " + ret);
-		}
+		nativeDispatcher._deregMr(mr.getObjId());
 		return this;
 	}
 	

--- a/src/main/java/com/ibm/disni/verbs/impl/NatIbvContext.java
+++ b/src/main/java/com/ibm/disni/verbs/impl/NatIbvContext.java
@@ -51,7 +51,7 @@ public class NatIbvContext extends IbvContext implements NatObject {
 	}
 
 	@Override
-	public int getNumCompVectors() {
+	public int getNumCompVectors() throws IOException {
 		if (this.numCompVectors < 0){
 			this.numCompVectors = nativeDispatcher._getContextNumCompVectors(objId);
 		}

--- a/src/main/java/com/ibm/disni/verbs/impl/NatPostRecvCall.java
+++ b/src/main/java/com/ibm/disni/verbs/impl/NatPostRecvCall.java
@@ -110,10 +110,7 @@ public class NatPostRecvCall extends SVCPostRecv {
 		if (!qp.isOpen()) {
 			throw new IOException("Trying to post receive on closed QP");
 		}
-		int ret = nativeDispatcher._postRecv(qp.getObjId(), cmd.address());
-		if (ret != 0){
-			throw new IOException("Post recv failed");
-		}
+		nativeDispatcher._postRecv(qp.getObjId(), cmd.address());
 		return this;
 	}
 

--- a/src/main/java/com/ibm/disni/verbs/impl/NatPostSendCall.java
+++ b/src/main/java/com/ibm/disni/verbs/impl/NatPostSendCall.java
@@ -111,10 +111,7 @@ public class NatPostSendCall extends SVCPostSend {
 		if (!qp.isOpen()) {
 			throw new IOException("Trying to post send on closed QP");
 		}
-		int ret = nativeDispatcher._postSend(qp.getObjId(), cmd.address());
-		if (ret != 0){
-			throw new IOException("Post send failed");
-		}
+		nativeDispatcher._postSend(qp.getObjId(), cmd.address());
 		return this;
 	}
 

--- a/src/main/java/com/ibm/disni/verbs/impl/NativeDispatcher.java
+++ b/src/main/java/com/ibm/disni/verbs/impl/NativeDispatcher.java
@@ -88,16 +88,18 @@ public class NativeDispatcher {
 	}
 
 	//rdmacm
-	public native long _createEventChannel();
-	public native long _createId(long channel, short rdma_ps);
-	public native long _createQP(long id, long pd, long sendcq, long recvcq, int qptype, int maxsendwr, int maxrecvwr, int maxinline);
-	public native int _bindAddr(long id, long addr);
-	public native int _listen(long id, int backlog);
-	public native int _resolveAddr(long id, long src, long dst, int timeout);
-	public native int _resolveRoute(long id, int timeout);
+	public native long _createEventChannel() throws IOException;
+	public native long _createId(long channel, short rdma_ps) throws IOException;
+	public native long _createQP(long id, long pd, long sendcq, long recvcq, int qptype, int maxsendwr, int maxrecvwr,
+								 int maxinline) throws IOException;
+	public native void _bindAddr(long id, long addr) throws IOException;
+	public native void _listen(long id, int backlog)  throws IOException;
+	public native void _resolveAddr(long id, long src, long dst, int timeout) throws IOException;
+	public native void _resolveRoute(long id, int timeout) throws IOException;
 	public native int _getCmEvent(long channel, long listenid, long clientid, int timeout);
-	public native int _connect(long id, int retrycount, int rnrretrycount, long privdataaddr, byte privdatalen);
-	public native int _accept(long id, int retrycount, int rnrretrycount);
+	public native void _connect(long id, int retrycount, int rnrretrycount, long privdataaddr, byte privdatalen)
+		throws IOException;
+	public native void _accept(long id, int retrycount, int rnrretrycount) throws IOException;
 	public native int _ackCmEvent(int cmEvent);
 	public native int _disconnect(long id);
 	public native int _destroyEventChannel(long fd);
@@ -108,30 +110,30 @@ public class NativeDispatcher {
 	public native int _destroyEp(long natid);
 
 	//ibverbs
-	public native long _allocPd(long context);
-	public native long _createCompChannel(long context);
-	public native long _createCQ(long context, long compChannel, int ncqe, int comp_vector);
-	public native int _modifyQP(long qp, long attr);
-	public native long _regMr(long pd, long addr, int len, int access, long lkey, long rkey, long handle);
+	public native long _allocPd(long context) throws IOException;
+	public native long _createCompChannel(long context) throws IOException;
+	public native long _createCQ(long context, long compChannel, int ncqe, int comp_vector) throws IOException;
+	public native int _modifyQP(long qp, long attr) throws IOException;
+	public native long _regMr(long pd, long addr, int len, int access, long lkey, long rkey, long handle) throws IOException;
 	public native int _queryOdpSupport(long context);
-	public native int _expPrefetchMr(long handle, long addr, int len);
-	public native int _deregMr(long handle);
-	public native int _postSend(long qp, long wrList);
-	public native int _postRecv(long qp, long wrList);
-	public native int _getCqEvent(long compChannel, int timeout);
-	public native int _pollCQ(long cq, int ne, long wclist);
-	public native int _reqNotifyCQ(long cq, int solicited_only);
+	public native int _expPrefetchMr(long handle, long addr, int len) throws IOException;
+	public native void _deregMr(long handle) throws IOException;
+	public native void _postSend(long qp, long wrList) throws IOException;
+	public native void _postRecv(long qp, long wrList) throws IOException;
+	public native int _getCqEvent(long compChannel, int timeout) throws IOException;
+	public native int _pollCQ(long cq, int ne, long wclist) throws IOException;
+	public native int _reqNotifyCQ(long cq, int solicited_only) throws IOException;
 	public native int _ackCqEvent(long cq, int nevents);
 	public native int _destroyCompChannel(long fd);
 	public native int _deallocPd(long handle);
 	public native int _destroyCQ(long handle);
 
 	//field lookup
-	public native long _getContext(long id);
-	public native int _getQpNum(long id);
-	public native int _getContextFd(long objId);
-	public native int _getContextNumCompVectors(long objId);
-	public native int _getPdHandle(long objId);
+	public native long _getContext(long id) throws IOException;
+	public native int _getQpNum(long id) throws IOException;
+	public native int _getContextFd(long objId) throws IOException;
+	public native int _getContextNumCompVectors(long objId) throws IOException;
+	public native int _getPdHandle(long objId) throws IOException;
 
 	//struct verification
 	public native int _getSockAddrInSize();

--- a/src/main/java/com/ibm/disni/verbs/impl/RdmaCmNat.java
+++ b/src/main/java/com/ibm/disni/verbs/impl/RdmaCmNat.java
@@ -119,7 +119,7 @@ public class RdmaCmNat extends RdmaCm {
 	}
 
 	@Override
-	public int bindAddr(RdmaCmId id, SocketAddress address)
+	public void bindAddr(RdmaCmId id, SocketAddress address)
 			throws IOException {
         InetSocketAddress _address = (InetSocketAddress) address;
         short _sin_family = SockAddrIn.AF_INET;
@@ -133,28 +133,26 @@ public class RdmaCmNat extends RdmaCm {
         if (!idPriv.isOpen()) {
             throw new IOException("Trying to bind() using a closed ID");
         }
-        int ret = nativeDispatcher._bindAddr(idPriv.getObjId(), sockBuf.address());
+        nativeDispatcher._bindAddr(idPriv.getObjId(), sockBuf.address());
         sockBuf.free();
         logger.info("bindAddr, address " + address.toString());
-
-        return ret;
 	}
 
 	@Override
-	public int listen(RdmaCmId id, int backlog) throws IOException {
+	public void listen(RdmaCmId id, int backlog) throws IOException {
 		NatCmaIdPrivate idPriv = (NatCmaIdPrivate) id;
 		if (!idPriv.isOpen()) {
 		    throw new IOException("Trying to listen on closed ID");
 		}
-		int ret = nativeDispatcher._listen(idPriv.getObjId(), backlog);
+		nativeDispatcher._listen(idPriv.getObjId(), backlog);
 		logger.info("listen, id " + id.getPs());
 		
-		return  ret;
+		return;
 	}
 
 	@Override
-	public int resolveAddr(RdmaCmId id, SocketAddress source,
-			SocketAddress destination, int timeout) throws IOException {
+	public void resolveAddr(RdmaCmId id, SocketAddress source,
+            SocketAddress destination, int timeout) throws IOException {
         InetSocketAddress _dst = (InetSocketAddress) destination;
         SockAddrIn dst = new SockAddrIn(SockAddrIn.AF_INET, NetUtils.getIntIPFromInetAddress(_dst.getAddress()), NetUtils.hostToNetworkByteOrder((short) _dst.getPort()));
         MemBuf dstBuf = memAlloc.allocate(SockAddrIn.CSIZE);
@@ -163,23 +161,23 @@ public class RdmaCmNat extends RdmaCm {
         if (!idPriv.isOpen()) {
             throw new IOException("Trying to resolve address with closed ID");
         }
-        int ret = nativeDispatcher._resolveAddr(idPriv.getObjId(), 0, dstBuf.address(), timeout);
+        nativeDispatcher._resolveAddr(idPriv.getObjId(), 0, dstBuf.address(), timeout);
         logger.info("resolveAddr, addres " + destination.toString());
         dstBuf.free();
         
-        return ret;
+        return;
 	}
 
 	@Override
-	public int resolveRoute(RdmaCmId id, int timeout) throws IOException {
+	public void resolveRoute(RdmaCmId id, int timeout) throws IOException {
 		NatCmaIdPrivate idPriv = (NatCmaIdPrivate) id;
         if (!idPriv.isOpen()) {
             throw new IOException("Trying to resolve route with closed ID");
         }
-		int ret = nativeDispatcher._resolveRoute(idPriv.getObjId(), timeout);
+		nativeDispatcher._resolveRoute(idPriv.getObjId(), timeout);
 		logger.info("resolveRoute, id " + id.getPs());
 		
-		return ret;
+		return;
 	}
 
 	@Override
@@ -213,32 +211,30 @@ public class RdmaCmNat extends RdmaCm {
 	}
 
 	@Override
-	public int connect(RdmaCmId id, RdmaConnParam connParam)
+	public void connect(RdmaCmId id, RdmaConnParam connParam)
 			throws IOException {
 		NatCmaIdPrivate idPriv = (NatCmaIdPrivate) id;
 		if (!idPriv.isOpen()) {
 			throw new IOException("Trying to call connect() with closed ID");
 		}
-		int ret = nativeDispatcher._connect(idPriv.getObjId(), connParam.getRetry_count(),
+		nativeDispatcher._connect(idPriv.getObjId(), connParam.getRetry_count(),
 				connParam.getRnr_retry_count(), connParam.getPrivate_data(), connParam.getPrivate_data_len());
-//		int ret = nativeDispatcher._connect(idPriv.getObjId(), (long) 0);
 		logger.info("connect, id " + id.getPs());
 		
-		return ret;
+		return;
 	}
 
 	@Override
-	public int accept(RdmaCmId id, RdmaConnParam connParam)
+	public void accept(RdmaCmId id, RdmaConnParam connParam)
 			throws IOException {
 		NatCmaIdPrivate idPriv = (NatCmaIdPrivate) id;
 		if (!idPriv.isOpen()) {
 			throw new IOException("Trying to call accept() with closed ID");
 		}
-		int ret = nativeDispatcher._accept(idPriv.getObjId(), connParam.getRetry_count(), connParam.getRnr_retry_count());
-//		int ret = nativeDispatcher._accept(idPriv.getObjId(), (long) 0);
+		nativeDispatcher._accept(idPriv.getObjId(), connParam.getRetry_count(), connParam.getRnr_retry_count());
 		logger.info("accept, id " + id.getPs());
 		
-		return ret;
+		return;
 	}
 
 	@Override

--- a/src/main/java/com/ibm/disni/verbs/impl/RdmaVerbsNat.java
+++ b/src/main/java/com/ibm/disni/verbs/impl/RdmaVerbsNat.java
@@ -141,12 +141,11 @@ public class RdmaVerbsNat extends RdmaVerbs {
 		return nativeDispatcher._queryOdpSupport(natContext.getObjId());
 	}
 
-	public int expPrefetchMr(IbvMr ibvMr, long address, int length){
+	public int expPrefetchMr(IbvMr ibvMr, long address, int length) throws IOException {
 		return nativeDispatcher._expPrefetchMr(((NatIbvMr)ibvMr).getObjId(), address, length);
 	}
 
-	public SVCDeregMr deregMr(IbvMr mr)
-			throws IOException {
+	public SVCDeregMr deregMr(IbvMr mr) {
 		return new NatDeregMrCall(this, nativeDispatcher, mr);
 	}
 

--- a/src/test/java/com/ibm/disni/examples/VerbsClient.java
+++ b/src/test/java/com/ibm/disni/examples/VerbsClient.java
@@ -55,11 +55,7 @@ public class VerbsClient {
 		//before connecting, we have to resolve addresses
 		InetAddress _dst = InetAddress.getByName(ipAddress);
 		InetSocketAddress dst = new InetSocketAddress(_dst, port);
-		int ret = idPriv.resolveAddr(null, dst, 2000);
-		if (ret < 0){
-			System.out.println("VerbsClient::resolveAddr failed");
-			return;
-		}
+		idPriv.resolveAddr(null, dst, 2000);
 
 		//resolve addr returns an event, we have to catch that event
 		RdmaCmEvent cmEvent = cmChannel.getCmEvent(-1);
@@ -74,12 +70,7 @@ public class VerbsClient {
 		cmEvent.ackEvent();
 
 		//we also have to resolve the route
-		ret = idPriv.resolveRoute(2000);
-		if (ret < 0){
-			System.out.println("VerbsClient::resolveRoute failed");
-			return;
-		}
-
+		idPriv.resolveRoute(2000);
 		//and catch that event too
 		cmEvent = cmChannel.getCmEvent(-1);
 		if (cmEvent == null){
@@ -174,11 +165,8 @@ public class VerbsClient {
 		//now let's connect to the server
 		RdmaConnParam connParam = new RdmaConnParam();
 		connParam.setRetry_count((byte) 2);
-		ret = idPriv.connect(connParam);
-		if (ret < 0){
-			System.out.println("VerbsClient::connect failed");
-			return;
-		}
+		idPriv.connect(connParam);
+
 
 		//wait until we are really connected
 		cmEvent = cmChannel.getCmEvent(-1);

--- a/src/test/java/com/ibm/disni/examples/VerbsServer.java
+++ b/src/test/java/com/ibm/disni/examples/VerbsServer.java
@@ -53,16 +53,10 @@ public class VerbsServer {
 
 		InetAddress _src = InetAddress.getByName(ipAddress);
 		InetSocketAddress src = new InetSocketAddress(_src, port);
-		int ret = idPriv.bindAddr(src);
-		if (ret < 0){
-			System.out.println("VerbsServer::binding not sucessfull");
-		}
+		idPriv.bindAddr(src);
 
 		//listen on the id
-		ret = idPriv.listen(10);
-		if (ret < 0){
-			System.out.println("VerbsServer::listen not successfull");
-		}
+		idPriv.listen(10);
 
 		//wait for new connect requests
 		RdmaCmEvent cmEvent = cmChannel.getCmEvent(-1);
@@ -140,11 +134,7 @@ public class VerbsServer {
 		RdmaConnParam connParam = new RdmaConnParam();
 		connParam.setRetry_count((byte) 2);
 		//once the client id is set up, accept the connection
-		ret = connId.accept(connParam);
-		if (ret < 0){
-			System.out.println("VerbsServer::accept failed");
-			return;
-		}
+		connId.accept(connParam);
 		//wait until the connection is officially switched into established mode
 		cmEvent = cmChannel.getCmEvent(-1);
 		if (cmEvent.getEvent() != RdmaCmEvent.EventType.RDMA_CM_EVENT_ESTABLISHED


### PR DESCRIPTION
If build libdisni with  `--enable-logging` it creates a lot of garbage in logs, printing a lot of unuseful information (every syscall in the hot path) - thus could not be used in production. Meanwhile if error happens on ibv/rdma calls it's not propagate to java stack, and difficult to figure out what happen. The easiest solution proposed in this PR is to print errors to stderr. Or we could use some configurable logging framework for C++, like [log4cxx](https://logging.apache.org/log4cxx/latest_stable/index.html), [glog](https://github.com/google/glog), etc.