### PR TITLE
Fix RdmavsTcpBenchmark issue.

### DIFF
--- a/src/test/java/com/ibm/disni/benchmarks/RDMAvsTcpBenchmarkClient.java
+++ b/src/test/java/com/ibm/disni/benchmarks/RDMAvsTcpBenchmarkClient.java
@@ -93,15 +93,15 @@ public class RDMAvsTcpBenchmarkClient implements RdmaEndpointFactory<CustomClien
     SVCPostSend postSend = endpoint.postSend(endpoint.getWrList_send());
     SVCPostRecv postRecv = endpoint.postRecv(endpoint.getWrList_recv());
     long startTime = System.nanoTime();
-    for (int i = 0; i < loopCount + 1; i++) {
+    for (int i = 0; i < loopCount; i++) {
       // Send PING
       sendBuf.clear();
       postSend.execute();
       endpoint.getWcEvents().take();
 
       // Recv PONG
-      postRecv.execute();
       endpoint.getWcEvents().take();
+      postRecv.execute();
       recvBuf.clear();
     }
     System.out.println("RDMA result:");

--- a/src/test/java/com/ibm/disni/benchmarks/RDMAvsTcpBenchmarkServer.java
+++ b/src/test/java/com/ibm/disni/benchmarks/RDMAvsTcpBenchmarkServer.java
@@ -91,10 +91,10 @@ public class RDMAvsTcpBenchmarkServer implements RdmaEndpointFactory<SendRecvSer
     ByteBuffer recvBuf = clientEndpoint.getRecvBuf();
     SVCPostSend postSend = clientEndpoint.postSend(clientEndpoint.getWrList_send());
     SVCPostRecv postRecv = clientEndpoint.postRecv(clientEndpoint.getWrList_recv());
-    for (int i = 0; i < loopCount + 1; i++){
+    for (int i = 0; i < loopCount; i++){
       // Recv PING
-      postRecv.execute();
       clientEndpoint.getWcEvents().take();
+      postRecv.execute();
       recvBuf.clear();
 
       //Send PONG


### PR DESCRIPTION
#37 Before `postRecv.execute()` need to call `endpoint.getWcEvents().take();` to not get stall buffer.