### PR TITLE
CM processor daemon thread

### DIFF
--- a/libdisni/configure.ac
+++ b/libdisni/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 #AC_PREREQ([2.67])
-AC_INIT([libdisni], [2.0], [https://github.com/zrlio/disni/issues])
+AC_INIT([libdisni], [2.1], [https://github.com/zrlio/disni/issues])
 AC_CONFIG_SRCDIR([src/verbs/com_ibm_disni_verbs_impl_NativeDispatcher.cpp])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.ibm.disni</groupId>
   <artifactId>disni</artifactId>
   <packaging>jar</packaging>
-  <version>2.0</version>
+  <version>2.1</version>
   <name>disni</name>
   <description>DiSNI (Direct Storage and Networking Interface) is a Java library for direct storage and networking access from userpace.</description>
   <url>http://github.com/zrlio/disni</url>

--- a/src/main/java/com/ibm/disni/RdmaCmProcessor.java
+++ b/src/main/java/com/ibm/disni/RdmaCmProcessor.java
@@ -33,32 +33,33 @@ import com.ibm.disni.verbs.RdmaEventChannel;
 import com.ibm.disni.util.DiSNILogger;
 
 /**
- * Responsible for processing communication events. 
+ * Responsible for processing communication events.
  */
 public class RdmaCmProcessor implements Runnable {
 	private static final Logger logger = DiSNILogger.getLogger();
-	
+
 	private RdmaEventChannel cmChannel;
 	private RdmaEndpointGroup<? extends RdmaEndpoint> cmConsumer;
 	private Thread thread;
 	private AtomicBoolean closed;
 	private int timeout;
-	
+
 	public RdmaCmProcessor(RdmaEndpointGroup<? extends RdmaEndpoint> cmConsumer, int timeout) throws IOException {
 		this.cmChannel = RdmaEventChannel.createEventChannel();
 		if (cmChannel == null){
 			throw new IOException("No RDMA device configured!");
 		}
-		this.cmConsumer = cmConsumer;		
+		this.cmConsumer = cmConsumer;
 		this.thread = new Thread(this);
+		this.thread.setDaemon(true);
 		closed = new AtomicBoolean(true);
 		this.timeout = timeout;
 	}
-	
+
 	public synchronized void start(){
 		closed.set(false);
 		thread.start();
-	}	
+	}
 
 	public void run() {
 		logger.info("launching cm processor, cmChannel " + cmChannel.getFd());
@@ -93,7 +94,7 @@ public class RdmaCmProcessor implements Runnable {
 		if (closed.get()){
 			return;
 		}
-		
+
 		closed.set(true);
 		thread.join();
 		logger.info("cm processor down");


### PR DESCRIPTION
Some application (e.g. Spark) rely on the application exiting
    when the main method returns. This requires all threads still
    active at the return of main to be daemon threads otherwise
    the application will wait for the threads to exit. This fix
    changes the RdmaCmProcessor thread to be a daemon thread.