### PR TITLE
RdmaServerEndpoint accept may return null, if listening endpoint closes.

### DIFF
--- a/src/main/java/com/ibm/disni/RdmaServerEndpoint.java
+++ b/src/main/java/com/ibm/disni/RdmaServerEndpoint.java
@@ -130,8 +130,12 @@ public class RdmaServerEndpoint<C extends RdmaEndpoint> {
 				}
 			}
 			C endpoint = requested.poll();
-			logger.info("connect request received");
-			endpoint.accept();
+
+			// a null endpoint gets returned if listening endpoint closes
+			if (endpoint != null) {
+				logger.info("connect request received");
+				endpoint.accept();
+			}
 			return endpoint;
 		} catch (Exception e) {
 			throw new IOException(e);


### PR DESCRIPTION
Closing the RdmaServerEndpoint in a current accept() lets a poll of the private accepting endpoint queue return null. This patch just avoids dereferencing that null endpoint during accept(). The caller of RdmaServerEndpoint.accept() must handle that case appropriately.